### PR TITLE
Use relative paths in redirects

### DIFF
--- a/main.go
+++ b/main.go
@@ -88,6 +88,7 @@ func main() {
 		fs.ServeHTTP(w, r)
 	})
 	http.HandleFunc("/api/kratos/self-service/login/browser", handleCreateFlow)
+	http.HandleFunc("/api/kratos/self-service/login/flows", handleLoginFlow)
 	http.HandleFunc("/api/kratos/self-service/login", handleUpdateFlow)
 	http.HandleFunc("/api/kratos/self-service/errors", handleKratosError)
 	http.HandleFunc("/api/consent", handleConsent)
@@ -155,6 +156,27 @@ func handleCreateFlow(w http.ResponseWriter, r *http.Request) {
 		Execute()
 	if e != nil {
 		log.Printf("Error when calling `FrontendApi.CreateBrowserLoginFlow`: %v\n", e)
+		log.Printf("Full HTTP response: %v\n", resp)
+		return
+	}
+
+	writeResponse(w, resp)
+
+	return
+}
+
+// TODO: Validate response when server error handling is implemented
+func handleLoginFlow(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+	kratos := NewKratosClient()
+
+	_, resp, e := kratos.FrontendApi.
+		GetLoginFlow(context.Background()).
+		Id(q.Get("id")).
+		Cookie(cookiesToString(r.Cookies())).
+		Execute()
+	if e != nil && resp.StatusCode != 422 {
+		log.Printf("Error when calling `FrontendApi.GetLoginFlow`: %v\n", e)
 		log.Printf("Full HTTP response: %v\n", resp)
 		return
 	}

--- a/ory_mocking/Handlers/handlers.go
+++ b/ory_mocking/Handlers/handlers.go
@@ -92,6 +92,19 @@ func SelfServiceLoginBrowserHandler(w http.ResponseWriter, r *http.Request) {
 	return
 }
 
+func SelfServiceGetLoginHandler(w http.ResponseWriter, r *http.Request) {
+	uiContainer := kratos_client.NewUiContainerWithDefaults()
+	response := kratos_client.NewLoginFlow(time.Now(), BROWSER_LOGIN_ID, time.Now(), r.URL.Path, BROWSER_LOGIN_TYPE, *uiContainer)
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+	jsonResp, err := json.Marshal(response)
+	if err != nil {
+		log.Printf("Bug in test: SelfServiceGetLogin\nerror: %s", err.Error())
+	}
+	w.Write(jsonResp)
+	return
+}
+
 func Oauth2AuthRequestLoginAcceptHandler(w http.ResponseWriter, r *http.Request) {
 	login := hydra_client.NewAcceptOAuth2LoginRequestWithDefaults()
 	data, err := ioutil.ReadAll(r.Body)

--- a/ory_mocking/Testservers/testservers.go
+++ b/ory_mocking/Testservers/testservers.go
@@ -20,6 +20,7 @@ func createKratosMockServer() *httptest.Server {
 	mux.HandleFunc("/self-service/errors", handlers.SelfServiceErrorsHandler)
 	mux.HandleFunc("/sessions/whoami", handlers.SessionWhoAmIHandler)
 	mux.HandleFunc("/self-service/login/browser", handlers.SelfServiceLoginBrowserHandler)
+	mux.HandleFunc("/self-service/login/flows", handlers.SelfServiceGetLoginHandler)
 	mux.HandleFunc("/self-service/login", handlers.SelfServiceLoginHandler)
 
 	s := httptest.NewServer(mux)
@@ -99,6 +100,7 @@ func createKratosErrorMockServer() *httptest.Server {
 	mux.HandleFunc("/self-service/errors", handlers.CreateHandlerWithError("SelfServiceErrorsHandler"))
 	mux.HandleFunc("/sessions/whoami", handlers.CreateHandlerWithError("SessionWhoAmIHandler"))
 	mux.HandleFunc("/self-service/login/browser", handlers.CreateHandlerWithError("SelfServiceLoginBrowserHandler"))
+	mux.HandleFunc("/self-service/login/flows", handlers.CreateHandlerWithError("SelfServiceGetLoginHandler"))
 	mux.HandleFunc("/self-service/login", handlers.CreateHandlerWithError("SelfServiceLoginHandler"))
 
 	s := httptest.NewServer(mux)

--- a/ui/components/Logo.tsx
+++ b/ui/components/Logo.tsx
@@ -3,7 +3,7 @@ import Image from "next/image"
 export default function Logo(){
     return (
       <div className="p-panel__logo u-align--center">
-        <Image src={ "/logo-canonical-aubergine.svg" } alt="" />
+        <Image src={ "./logo-canonical-aubergine.svg" } alt="" />
       </div>
     )
 }

--- a/ui/components/hydra.ts
+++ b/ui/components/hydra.ts
@@ -3,7 +3,8 @@ import { Configuration, OAuth2Api } from "@ory/client"
 
 const hydraAdmin = new OAuth2Api(
   new Configuration({
-    basePath: "/api/hydra",
+  // Use relative path so that this works when served in a subpath
+    basePath: "./api/hydra",
     baseOptions: {
       withCredentials: true,
     },

--- a/ui/components/sdk.ts
+++ b/ui/components/sdk.ts
@@ -1,7 +1,8 @@
 import { Configuration, FrontendApi } from "@ory/client"
 
 export const kratos = new FrontendApi(  new Configuration({
-  basePath: "/api/kratos",
+  // Use relative path so that this works when served in a subpath
+  basePath: "./api/kratos",
   baseOptions: {
     withCredentials: true,
   },

--- a/ui/next.config.js
+++ b/ui/next.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   "images":{
     "unoptimized": true
-  }
+  },
+  assetPrefix: "./"
 }

--- a/ui/pages/consent.tsx
+++ b/ui/pages/consent.tsx
@@ -14,7 +14,7 @@ const Consent: NextPage = () => {
       return
     }
 
-    get("/api/consent?consent_challenge=" + consent_challenge)
+    get("./api/consent?consent_challenge=" + consent_challenge)
     .then(({ data : body}) => {
       window.location.href = body.redirect_to
     })
@@ -23,12 +23,12 @@ const Consent: NextPage = () => {
         case 403:
           // This is a legacy error code thrown. See code 422 for
           // more details.
-          return router.push("/login?aal=aal2")
+          return router.push("./login?aal=aal2")
         case 422:
           // This status code is returned when we are trying to
           // validate a session which has not yet completed
           // its second factor
-          return router.push("/login?aal=aal2")
+          return router.push("./login?aal=aal2")
         case 401:
           // do nothing, the user is not logged in
           return

--- a/ui/pages/login.tsx
+++ b/ui/pages/login.tsx
@@ -109,7 +109,7 @@ const Login: NextPage = () => {
               <Card title="Choose Provider" >
                 <Flow onSubmit={onSubmit} flow={flow} />
               </Card> :
-              <Spinner></Spinner>
+              <Spinner />
             }
           </div>
         </div>

--- a/ui/pages/login.tsx
+++ b/ui/pages/login.tsx
@@ -61,38 +61,41 @@ const Login: NextPage = () => {
       })
       .catch(handleFlowError(router, "login", setFlow))
   }, [flowId, router, router.isReady, aal, refresh, returnTo, flow, login_challenge])
-  const onSubmit = useCallback((values: UpdateLoginFlowBody) =>
-    router
-      // On submission, add the flow ID to the URL but do not navigate. This prevents the user loosing
-      // his data when she/he reloads the page.
-      .push(`/login?flow=${flow?.id}`, undefined, { shallow: true })
-      .then(() =>
-        kratos
-          .updateLoginFlow({
-            flow: String(flow?.id),
-            updateLoginFlowBody: values,
-          })
-          // We logged in successfully! Let's bring the user home.
-          .then(() => {
-            if (flow?.return_to) {
-              window.location.href = flow?.return_to
-              return
-            }
-            router.push("/")
-          })
-          .then(() => {})
-          .catch(handleFlowError(router, "login", setFlow))
-          .catch((err: AxiosError) => {
-            // If the previous handler did not catch the error it's most likely a form validation error
-            if (err.response?.status === 400) {
-              // Yup, it is!
-              setFlow(err.response?.data)
-              return
-            }
+  const onSubmit = useCallback((values: UpdateLoginFlowBody) => {
+    // if (!router.query.flow) {
+    //   // On submission, add the flow ID to the URL but do not navigate. This prevents the user loosing
+    //   // his data when she/he reloads the page.
+    //   // We use relative path so that this works when behind traefik (traefik will serve this
+    //   // page on a subpath)
+    //   router.push(`${window.location.pathname}/?flow=${flow?.id}`, undefined, { shallow: true })
+    //   navigate({pathname: ".", })
+    // }
+    return kratos
+      .updateLoginFlow({
+        flow: String(flow?.id),
+        updateLoginFlowBody: values,
+      })
+      // We logged in successfully! Let's bring the user home.
+      .then(() => {
+        if (flow?.return_to) {
+          window.location.href = flow?.return_to
+          return
+        }
+        router.push("/")
+      })
+      .then(() => { })
+      .catch(handleFlowError(router, "login", setFlow))
+      .catch((err: AxiosError) => {
+        // If the previous handler did not catch the error it's most likely a form validation error
+        if (err.response?.status === 400) {
+          // Yup, it is!
+          setFlow(err.response?.data)
+          return
+        }
 
-            return Promise.reject(err)
-          }),
-      ), [flow, router, ])
+        return Promise.reject(err)
+      })
+  }, [flow, router])
   return (
     <>
       <Head>
@@ -102,12 +105,12 @@ const Login: NextPage = () => {
       <div className="p-strip">
         <div className="login-card">
           <div>
-          {flow ?
-          <Card title="Choose Provider" >
-            <Flow onSubmit={onSubmit} flow={flow} />
-          </Card>:
-          <Spinner></Spinner>
-          }
+            {flow ?
+              <Card title="Choose Provider" >
+                <Flow onSubmit={onSubmit} flow={flow} />
+              </Card> :
+              <Spinner></Spinner>
+            }
           </div>
         </div>
       </div>


### PR DESCRIPTION
When the UI is served behind a reverse proxy (e.g. traefik), the pages may be served under a subpath. This breaks our redirects and calls to the backend API. In order to overcome this we use relative paths everywhere.

This is not the proper solution and ideally we would want the reverse proxy to inject the html with the base URL tag.