### PR TITLE
Iam 307 implement health checks

### DIFF
--- a/health/health.go
+++ b/health/health.go
@@ -1,0 +1,81 @@
+package health
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+)
+
+const okValue = "ok"
+
+var aliveSingleton Status
+var readySingleton Status
+
+type Status struct {
+	Status  string `json:"status"`
+	Message string `json:"message,omitempty"`
+}
+
+func getAlive() Status {
+	if aliveSingleton.Status == "" {
+		aliveSingleton = Status{Status: okValue}
+	}
+	return aliveSingleton
+}
+
+func getReady() Status {
+	if readySingleton.Status == "" {
+		readySingleton = Status{Status: okValue}
+	}
+	return readySingleton
+}
+
+func SetUnAlive(msg string) {
+	aliveSingleton = Status{
+		Status:  http.StatusText(503),
+		Message: msg,
+	}
+}
+
+func SetUnReady(msg string) {
+	readySingleton = Status{
+		Status:  http.StatusText(503),
+		Message: msg,
+	}
+}
+
+func HandleAlive(w http.ResponseWriter, r *http.Request) {
+	status := getAlive()
+	w.Header().Set("Content-Type", "application/json")
+	if status.Status == okValue {
+		w.WriteHeader(200)
+	} else {
+		w.WriteHeader(503)
+	}
+	body, err := json.Marshal(status)
+	if err != nil {
+		log.Printf("Error during Health Check Liveness Check\nerror: %s", err.Error())
+	}
+	w.Write(body)
+	return
+}
+
+func HandleReady(w http.ResponseWriter, r *http.Request) {
+	status := getReady()
+	w.Header().Set("Content-Type", "application/json")
+	if status.Status == okValue {
+		w.WriteHeader(200)
+	} else {
+		w.WriteHeader(503)
+	}
+	body, err := json.Marshal(status)
+	if err != nil {
+		log.Printf("Error during Health Check Liveness Check\nerror: %s", err.Error())
+	}
+	w.Write(body)
+	return
+}
+
+func EmptyStatus() *Status {
+	return &Status{}
+}

--- a/health/health.go
+++ b/health/health.go
@@ -120,24 +120,25 @@ func EmptyStatus() *Status {
 }
 
 func readinessChecker() bool {
-	fmt.Fprintf(os.Stderr, "debug- checkready start kratos\n")
 	_, r, err := kratos.MetadataApi.IsReady(context.Background()).Execute()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error when calling Kratos with `MetadataApi.IsReady``: %v\n", err)
 		fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
 		return false
 	} else if r.StatusCode != 200 {
-		fmt.Fprintf(os.Stderr, "debug- status not 200 kratos\n")
+		fmt.Fprintf(os.Stderr, "Error when calling Kratos with `MetadataApi.IsReady``: %v\n", err)
+		fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
 		return false
 	}
-	fmt.Fprintf(os.Stderr, "debug- heckready start hydra")
+
 	_, r, err = hydra.MetadataApi.IsReady(context.Background()).Execute()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error when calling Hydra with `MetadataApi.IsReady``: %v\n", err)
 		fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
 		return false
 	} else if r.StatusCode != 200 {
-		fmt.Fprintf(os.Stderr, "debug- status not 200 hydra\n")
+		fmt.Fprintf(os.Stderr, "Error when calling Hydra with `MetadataApi.IsReady``: %v\n", err)
+		fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
 		return false
 	}
 	return true
@@ -153,4 +154,12 @@ func TestHandleAlive(w http.ResponseWriter, r *http.Request) {
 
 func TestHandleReady(w http.ResponseWriter, r *http.Request) {
 	handleReady(w, r)
+}
+
+func TestResetHealth() {
+	aliveSingleton = Status{}
+	readySingleton = Status{}
+	kratos = nil
+	hydra = nil
+	apiClientSet = false
 }

--- a/health/health.go
+++ b/health/health.go
@@ -44,6 +44,10 @@ func SetUnReady(msg string) {
 	}
 }
 
+func SetReady() {
+	readySingleton = Status{Status: okValue}
+}
+
 func HandleAlive(w http.ResponseWriter, r *http.Request) {
 	status := getAlive()
 	w.Header().Set("Content-Type", "application/json")

--- a/health/health.go
+++ b/health/health.go
@@ -2,15 +2,11 @@ package health
 
 import (
 	"encoding/json"
-	"fmt"
 	"log"
 	"net/http"
-	"os"
 )
 
 const okValue = "ok"
-const kratosEnvar = "KRATOS_PUBLIC_URL"
-const hydraEnvar = "HYDRA_ADMIN_URL"
 
 var aliveSingleton Status
 var readySingleton Status
@@ -22,19 +18,14 @@ type Status struct {
 
 func getAlive() Status {
 	if aliveSingleton.Status == EmptyStatus().Status {
-		aliveSingleton = Status{Status: okValue}
+		setAlive()
 	}
 	return aliveSingleton
 }
 
 func getReady() Status {
-	if readySingleton.Status != okValue {
-		isReady, msg := readinessChecker()
-		if isReady {
-			setReady()
-		} else {
-			setUnReady(msg)
-		}
+	if readySingleton.Status == EmptyStatus().Status {
+		setReady()
 	}
 	return readySingleton
 }
@@ -55,6 +46,10 @@ func setUnReady(msg string) {
 
 func setReady() {
 	readySingleton = Status{Status: okValue}
+}
+
+func setAlive() {
+	aliveSingleton = Status{Status: okValue}
 }
 
 func HandleAlive(w http.ResponseWriter, r *http.Request) {
@@ -93,26 +88,12 @@ func EmptyStatus() *Status {
 	return &Status{}
 }
 
-func readinessChecker() (bool, string) {
-	result := true
-	errorMessage := "Error:"
-	if kratosURL := os.Getenv(kratosEnvar); kratosURL == "" {
-		errorMessage = fmt.Sprintf("%s Kratos endpoint not set.", errorMessage)
-		result = false
-	}
-	if hydraURL := os.Getenv(hydraEnvar); hydraURL == "" {
-		errorMessage = fmt.Sprintf("%s Hydra endpoint not set.", errorMessage)
-		result = false
-	}
-
-	if result {
-		return result, ""
-	}
-	return result, errorMessage
-}
-
 func TestSetUnalive(msg string) {
 	setUnAlive(msg)
+}
+
+func TestSetUnready(msg string) {
+	setUnReady(msg)
 }
 
 func TestResetHealth() {

--- a/health/health.go
+++ b/health/health.go
@@ -73,14 +73,14 @@ func GetAliveHandler() (func(w http.ResponseWriter, r *http.Request), error) {
 	if apiClientSet {
 		return handleAlive, nil
 	}
-	return nil, errors.New("API Clients not set in health")
+	return nil, errors.New("API Clients not set")
 }
 
 func GetReadyHandler() (func(w http.ResponseWriter, r *http.Request), error) {
 	if apiClientSet {
 		return handleReady, nil
 	}
-	return nil, errors.New("API Clients not set health")
+	return nil, errors.New("API Clients not set")
 }
 
 func handleAlive(w http.ResponseWriter, r *http.Request) {

--- a/main.go
+++ b/main.go
@@ -379,15 +379,13 @@ func ReadinessChecker() {
 		done <- true
 	}
 
-	go func() {
-		for {
-			select {
-			case <-done:
-				health.SetReady()
-				return
-			case <-Ticker.C:
-				CheckReady()
-			}
+	for {
+		select {
+		case <-done:
+			health.SetReady()
+			return
+		case <-Ticker.C:
+			CheckReady()
 		}
-	}()
+	}
 }

--- a/main.go
+++ b/main.go
@@ -78,18 +78,6 @@ func NewHydraClient() *hydra_client.APIClient {
 }
 
 func main() {
-	health.SetApiClients(NewKratosClient(), NewHydraClient())
-	handleAlive, err := health.GetAliveHandler()
-	if err != nil {
-		log.Printf("%v\n", err)
-		return
-	}
-	handleReady, err := health.GetReadyHandler()
-	if err != nil {
-		log.Printf("%v\n", err)
-		return
-	}
-
 	dist, _ := fs.Sub(ui, "ui/dist")
 	fs := http.FileServer(http.FS(dist))
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
@@ -105,8 +93,8 @@ func main() {
 	http.HandleFunc("/api/kratos/self-service/login", handleUpdateFlow)
 	http.HandleFunc("/api/kratos/self-service/errors", handleKratosError)
 	http.HandleFunc("/api/consent", handleConsent)
-	http.HandleFunc("/health/alive", handleAlive)
-	http.HandleFunc("/health/ready", handleReady)
+	http.HandleFunc("/health/alive", health.HandleAlive)
+	http.HandleFunc("/health/ready", health.HandleReady)
 
 	port := os.Getenv("PORT")
 

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"embed"
 	"encoding/json"
 	"fmt"
+	"identity_platform_login_ui/health"
 	"io/fs"
 	"io/ioutil"
 	"log"
@@ -92,6 +93,8 @@ func main() {
 	http.HandleFunc("/api/kratos/self-service/login", handleUpdateFlow)
 	http.HandleFunc("/api/kratos/self-service/errors", handleKratosError)
 	http.HandleFunc("/api/consent", handleConsent)
+	http.HandleFunc("/health/alive", health.HandleAlive)
+	http.HandleFunc("/health/ready", health.HandleReady)
 
 	port := os.Getenv("PORT")
 

--- a/main_test.go
+++ b/main_test.go
@@ -306,7 +306,6 @@ func TestHandleConsentError(t *testing.T) {
 // --------------------------------------------
 func TestAliveOK(t *testing.T) {
 	health.TestResetHealth()
-	testServers.ClearEnvars(t)
 	req := httptest.NewRequest(http.MethodGet, HANDLE_ALIVE_URL, nil)
 	w := httptest.NewRecorder()
 	health.HandleAlive(w, req)
@@ -325,7 +324,6 @@ func TestAliveOK(t *testing.T) {
 
 func TestAliveFail(t *testing.T) {
 	health.TestResetHealth()
-	testServers.ClearEnvars(t)
 	testMessage := "Liveness Check failed for test"
 	health.TestSetUnalive(testMessage)
 
@@ -349,8 +347,6 @@ func TestAliveFail(t *testing.T) {
 func TestReadyOK(t *testing.T) {
 	//init clients
 	health.TestResetHealth()
-	testServers.ClearEnvars(t)
-	testServers.CreateTestServers(t)
 
 	req := httptest.NewRequest(http.MethodGet, HANDLE_ALIVE_URL, nil)
 	w := httptest.NewRecorder()
@@ -371,11 +367,11 @@ func TestReadyOK(t *testing.T) {
 func TestReadyFail(t *testing.T) {
 	health.TestResetHealth()
 	testServers.ClearEnvars(t)
-	testMessage := "Error: Kratos endpoint not set. Hydra endpoint not set."
+	testMessage := "Readiness Check failed for test"
 
 	req := httptest.NewRequest(http.MethodGet, HANDLE_READY_URL, nil)
 	w := httptest.NewRecorder()
-	//health.TestSetUnready(testMessage)
+	health.TestSetUnready(testMessage)
 	health.HandleReady(w, req)
 	res := w.Result()
 	defer res.Body.Close()

--- a/main_test.go
+++ b/main_test.go
@@ -307,7 +307,7 @@ func TestHandleConsentError(t *testing.T) {
 func TestAliveOK(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, HANDLE_ALIVE_URL, nil)
 	w := httptest.NewRecorder()
-	health.HandleAlive(w, req)
+	health.TestHandleAlive(w, req)
 	res := w.Result()
 	defer res.Body.Close()
 	data, err := ioutil.ReadAll(res.Body)
@@ -323,10 +323,11 @@ func TestAliveOK(t *testing.T) {
 
 func TestAliveFail(t *testing.T) {
 	testMessage := "Liveness Check failed for test"
+	health.TestSetUnalive(testMessage)
+
 	req := httptest.NewRequest(http.MethodGet, HANDLE_ALIVE_URL, nil)
 	w := httptest.NewRecorder()
-	health.SetUnAlive(testMessage)
-	health.HandleAlive(w, req)
+	health.TestHandleAlive(w, req)
 	res := w.Result()
 	defer res.Body.Close()
 	data, err := ioutil.ReadAll(res.Body)
@@ -342,9 +343,13 @@ func TestAliveFail(t *testing.T) {
 }
 
 func TestReadyOK(t *testing.T) {
+	//init clients
+	testServers.CreateTestServers(t)
+	health.SetApiClients(NewKratosClient(), NewHydraClient())
+
 	req := httptest.NewRequest(http.MethodGet, HANDLE_ALIVE_URL, nil)
 	w := httptest.NewRecorder()
-	health.HandleReady(w, req)
+	health.TestHandleReady(w, req)
 	res := w.Result()
 	defer res.Body.Close()
 	data, err := ioutil.ReadAll(res.Body)
@@ -359,11 +364,14 @@ func TestReadyOK(t *testing.T) {
 }
 
 func TestReadyFail(t *testing.T) {
-	testMessage := "Readiness Check failed for test"
+	testMessage := "Ory backend have not been confirmed to be available"
+	testServers.CreateErrorServers(t)
+	health.SetApiClients(NewKratosClient(), NewHydraClient())
+
 	req := httptest.NewRequest(http.MethodGet, HANDLE_READY_URL, nil)
 	w := httptest.NewRecorder()
-	health.SetUnReady(testMessage)
-	health.HandleReady(w, req)
+	//health.TestSetUnready(testMessage)
+	health.TestHandleReady(w, req)
 	res := w.Result()
 	defer res.Body.Close()
 	data, err := ioutil.ReadAll(res.Body)

--- a/main_test.go
+++ b/main_test.go
@@ -306,9 +306,10 @@ func TestHandleConsentError(t *testing.T) {
 // --------------------------------------------
 func TestAliveOK(t *testing.T) {
 	health.TestResetHealth()
+	testServers.ClearEnvars(t)
 	req := httptest.NewRequest(http.MethodGet, HANDLE_ALIVE_URL, nil)
 	w := httptest.NewRecorder()
-	health.TestHandleAlive(w, req)
+	health.HandleAlive(w, req)
 	res := w.Result()
 	defer res.Body.Close()
 	data, err := ioutil.ReadAll(res.Body)
@@ -324,12 +325,13 @@ func TestAliveOK(t *testing.T) {
 
 func TestAliveFail(t *testing.T) {
 	health.TestResetHealth()
+	testServers.ClearEnvars(t)
 	testMessage := "Liveness Check failed for test"
 	health.TestSetUnalive(testMessage)
 
 	req := httptest.NewRequest(http.MethodGet, HANDLE_ALIVE_URL, nil)
 	w := httptest.NewRecorder()
-	health.TestHandleAlive(w, req)
+	health.HandleAlive(w, req)
 	res := w.Result()
 	defer res.Body.Close()
 	data, err := ioutil.ReadAll(res.Body)
@@ -347,12 +349,12 @@ func TestAliveFail(t *testing.T) {
 func TestReadyOK(t *testing.T) {
 	//init clients
 	health.TestResetHealth()
+	testServers.ClearEnvars(t)
 	testServers.CreateTestServers(t)
-	health.SetApiClients(NewKratosClient(), NewHydraClient())
 
 	req := httptest.NewRequest(http.MethodGet, HANDLE_ALIVE_URL, nil)
 	w := httptest.NewRecorder()
-	health.TestHandleReady(w, req)
+	health.HandleReady(w, req)
 	res := w.Result()
 	defer res.Body.Close()
 	data, err := ioutil.ReadAll(res.Body)
@@ -368,14 +370,13 @@ func TestReadyOK(t *testing.T) {
 
 func TestReadyFail(t *testing.T) {
 	health.TestResetHealth()
-	testMessage := "Ory backend have not been confirmed to be available"
-	testServers.CreateErrorServers(t)
-	health.SetApiClients(NewKratosClient(), NewHydraClient())
+	testServers.ClearEnvars(t)
+	testMessage := "Error: Kratos endpoint not set. Hydra endpoint not set."
 
 	req := httptest.NewRequest(http.MethodGet, HANDLE_READY_URL, nil)
 	w := httptest.NewRecorder()
 	//health.TestSetUnready(testMessage)
-	health.TestHandleReady(w, req)
+	health.HandleReady(w, req)
 	res := w.Result()
 	defer res.Body.Close()
 	data, err := ioutil.ReadAll(res.Body)

--- a/main_test.go
+++ b/main_test.go
@@ -305,6 +305,7 @@ func TestHandleConsentError(t *testing.T) {
 // TESTING HEALTH CHECKS
 // --------------------------------------------
 func TestAliveOK(t *testing.T) {
+	health.TestResetHealth()
 	req := httptest.NewRequest(http.MethodGet, HANDLE_ALIVE_URL, nil)
 	w := httptest.NewRecorder()
 	health.TestHandleAlive(w, req)
@@ -322,6 +323,7 @@ func TestAliveOK(t *testing.T) {
 }
 
 func TestAliveFail(t *testing.T) {
+	health.TestResetHealth()
 	testMessage := "Liveness Check failed for test"
 	health.TestSetUnalive(testMessage)
 
@@ -344,6 +346,7 @@ func TestAliveFail(t *testing.T) {
 
 func TestReadyOK(t *testing.T) {
 	//init clients
+	health.TestResetHealth()
 	testServers.CreateTestServers(t)
 	health.SetApiClients(NewKratosClient(), NewHydraClient())
 
@@ -364,6 +367,7 @@ func TestReadyOK(t *testing.T) {
 }
 
 func TestReadyFail(t *testing.T) {
+	health.TestResetHealth()
 	testMessage := "Ory backend have not been confirmed to be available"
 	testServers.CreateErrorServers(t)
 	health.SetApiClients(NewKratosClient(), NewHydraClient())

--- a/ory_mocking/Handlers/handlers.go
+++ b/ory_mocking/Handlers/handlers.go
@@ -62,6 +62,10 @@ type GenericError struct {
 	Status  string `json:"status"`
 }
 
+type Status struct {
+	Status string `json:"status"`
+}
+
 func GenericErrorConstructor(testname string) GenericError {
 	error := GenericError{
 		Code:    DEFAULT_ERROR_CODE,
@@ -229,5 +233,33 @@ func CreateHandlerWithError(testname string) func(w http.ResponseWriter, r *http
 
 func TimeoutHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusGatewayTimeout)
+	return
+}
+
+func GetOKStatus(w http.ResponseWriter, r *http.Request) {
+	status := Status{
+		Status: "ok",
+	}
+	jsonResp, err := json.Marshal(status)
+	if err != nil {
+		log.Printf("Bug in test handler: GetOKStatus\nerror: %s", err.Error())
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+	w.Write(jsonResp)
+	return
+}
+
+func GetErrorStatus(w http.ResponseWriter, r *http.Request) {
+	status := Status{
+		Status: http.StatusText(503),
+	}
+	jsonResp, err := json.Marshal(status)
+	if err != nil {
+		log.Printf("Bug in test handler: GetOKStatus\nerror: %s", err.Error())
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(503)
+	w.Write(jsonResp)
 	return
 }

--- a/ory_mocking/Testservers/testservers.go
+++ b/ory_mocking/Testservers/testservers.go
@@ -22,6 +22,8 @@ func createKratosMockServer() *httptest.Server {
 	mux.HandleFunc("/self-service/login/browser", handlers.SelfServiceLoginBrowserHandler)
 	mux.HandleFunc("/self-service/login/flows", handlers.SelfServiceGetLoginHandler)
 	mux.HandleFunc("/self-service/login", handlers.SelfServiceLoginHandler)
+	mux.HandleFunc("/health/alive", handlers.GetOKStatus)
+	mux.HandleFunc("/health/ready", handlers.GetOKStatus)
 
 	s := httptest.NewServer(mux)
 	os.Setenv("KRATOS_PUBLIC_URL", s.URL)
@@ -32,6 +34,9 @@ func createHydraMockServer() *httptest.Server {
 	mux.HandleFunc("/admin/oauth2/auth/requests/login/accept", handlers.Oauth2AuthRequestLoginAcceptHandler)
 	mux.HandleFunc("/admin/oauth2/auth/requests/consent", handlers.Oauth2AuthRequestConsentHandler)
 	mux.HandleFunc("/admin/oauth2/auth/requests/consent/accept", handlers.Oauth2AuthRequestConsentAcceptHandler)
+	mux.HandleFunc("/health/alive", handlers.GetOKStatus)
+	mux.HandleFunc("/health/ready", handlers.GetOKStatus)
+
 	s := httptest.NewServer(mux)
 	os.Setenv("HYDRA_ADMIN_URL", s.URL)
 	return s
@@ -102,6 +107,8 @@ func createKratosErrorMockServer() *httptest.Server {
 	mux.HandleFunc("/self-service/login/browser", handlers.CreateHandlerWithError("SelfServiceLoginBrowserHandler"))
 	mux.HandleFunc("/self-service/login/flows", handlers.CreateHandlerWithError("SelfServiceGetLoginHandler"))
 	mux.HandleFunc("/self-service/login", handlers.CreateHandlerWithError("SelfServiceLoginHandler"))
+	mux.HandleFunc("/health/alive", handlers.GetErrorStatus)
+	mux.HandleFunc("/health/ready", handlers.GetErrorStatus)
 
 	s := httptest.NewServer(mux)
 	os.Setenv("KRATOS_PUBLIC_URL", s.URL+"/")
@@ -112,6 +119,9 @@ func createHydraErrorMockServer() *httptest.Server {
 	mux.HandleFunc("/admin/oauth2/auth/requests/login/accept", handlers.CreateHandlerWithError("Oauth2AuthRequestLoginAcceptHandler"))
 	mux.HandleFunc("/admin/oauth2/auth/requests/consent", handlers.CreateHandlerWithError("Oauth2AuthRequestConsentHandler"))
 	mux.HandleFunc("/admin/oauth2/auth/requests/consent/accept", handlers.CreateHandlerWithError("Oauth2AuthRequestConsentAcceptHandler"))
+	mux.HandleFunc("/health/alive", handlers.GetErrorStatus)
+	mux.HandleFunc("/health/ready", handlers.GetErrorStatus)
+
 	s := httptest.NewServer(mux)
 	os.Setenv("HYDRA_ADMIN_URL", s.URL)
 	return s

--- a/ory_mocking/Testservers/testservers.go
+++ b/ory_mocking/Testservers/testservers.go
@@ -132,3 +132,20 @@ func CreateErrorServers(t *testing.T) {
 	t.Cleanup(ekratos.Close)
 	t.Cleanup(ehydra.Close)
 }
+
+func ClearEnvars(t *testing.T) {
+	if _, ok := os.LookupEnv("HYDRA_ADMIN_URL"); ok {
+		err := os.Unsetenv("HYDRA_ADMIN_URL")
+		if err != nil {
+			t.Errorf("expected error to be nil got %v", err)
+		}
+	}
+	if _, ok := os.LookupEnv("KRATOS_PUBLIC_URL"); ok {
+		err := os.Unsetenv("KRATOS_PUBLIC_URL")
+		if err != nil {
+			t.Errorf("expected error to be nil got %v", err)
+		}
+	}
+
+	return
+}


### PR DESCRIPTION
This PR implements liveness and readiness checks for the Login UI server. Readiness response is only available if dependencies are also available.

Liveness check is available at /health/alive. This check returns with {"status": "ok"} if the server is running. Currently the endpoint isn't configured to return with other values, so a http timeout error during liveness check implies the server is down.

Readiness check is available at /health/ready. This check returns with {"status": "ok"} if the server is running. Currently the endpoint isn't configured to return with other values, so a http timeout error during readiness check implies the server is down.

EDIT: Updated the logic in responding to /health/ready
EDIT 2: Updated the logic in responding to /health/ready so ready=ok means the server is running
