### PR TITLE
IAM-307 Liveness check implementation

### DIFF
--- a/health/health.go
+++ b/health/health.go
@@ -1,8 +1,5 @@
 package health
 
-//Notes on Thread safety: Currently we only expose methods that read the state of the singletons therefore thread safety is not an issue.
-//In case the scope of use case for Health expands: Implement RWLocks for the singleton variables, or implement using buffered channels to change state
-
 import (
 	"encoding/json"
 	"log"
@@ -11,59 +8,26 @@ import (
 
 const okValue = "ok"
 
-var aliveSingleton Status
-var readySingleton Status
-
 type Status struct {
 	Status  string `json:"status"`
 	Message string `json:"message,omitempty"`
 }
 
-func getAlive() Status {
-	if aliveSingleton.Status == EmptyStatus().Status {
-		SetAlive()
-	}
-	return aliveSingleton
-}
-
-func getReady() Status {
-	if readySingleton.Status == EmptyStatus().Status {
-		SetReady()
-	}
-	return readySingleton
-}
-
-func SetUnAlive(msg string) {
-	aliveSingleton = Status{
-		Status:  http.StatusText(503),
+func GetNotOKStatus(msg string) Status {
+	return Status{
+		Status:  http.StatusText(http.StatusServiceUnavailable),
 		Message: msg,
 	}
 }
 
-func SetUnReady(msg string) {
-	readySingleton = Status{
-		Status:  http.StatusText(503),
-		Message: msg,
-	}
-}
-
-func SetReady() {
-	readySingleton = Status{Status: okValue}
-}
-
-func SetAlive() {
-	aliveSingleton = Status{Status: okValue}
+func GetOKStatus() Status {
+	return Status{Status: okValue}
 }
 
 func HandleAlive(w http.ResponseWriter, r *http.Request) {
-	status := getAlive()
 	w.Header().Set("Content-Type", "application/json")
-	if status.Status == okValue {
-		w.WriteHeader(200)
-	} else {
-		w.WriteHeader(503)
-	}
-	body, err := json.Marshal(status)
+	w.WriteHeader(http.StatusOK)
+	body, err := json.Marshal(GetOKStatus())
 	if err != nil {
 		log.Printf("Error during Health Check Liveness Check\nerror: %s", err.Error())
 	}
@@ -72,16 +36,11 @@ func HandleAlive(w http.ResponseWriter, r *http.Request) {
 }
 
 func HandleReady(w http.ResponseWriter, r *http.Request) {
-	status := getReady()
 	w.Header().Set("Content-Type", "application/json")
-	if status.Status == okValue {
-		w.WriteHeader(200)
-	} else {
-		w.WriteHeader(503)
-	}
-	body, err := json.Marshal(status)
+	w.WriteHeader(http.StatusOK)
+	body, err := json.Marshal(GetOKStatus())
 	if err != nil {
-		log.Printf("Error during Health Check Readiness Check\nerror: %s", err.Error())
+		log.Printf("Error during Health Check Liveness Check\nerror: %s", err.Error())
 	}
 	w.Write(body)
 	return
@@ -89,9 +48,4 @@ func HandleReady(w http.ResponseWriter, r *http.Request) {
 
 func EmptyStatus() *Status {
 	return &Status{}
-}
-
-func TestResetHealth() {
-	aliveSingleton = Status{}
-	readySingleton = Status{}
 }

--- a/health/health.go
+++ b/health/health.go
@@ -2,50 +2,19 @@ package health
 
 import (
 	"encoding/json"
-	"log"
 	"net/http"
 )
 
 const okValue = "ok"
 
 type Status struct {
-	Status  string `json:"status"`
-	Message string `json:"message,omitempty"`
-}
-
-func GetNotOKStatus(msg string) Status {
-	return Status{
-		Status:  http.StatusText(http.StatusServiceUnavailable),
-		Message: msg,
-	}
-}
-
-func GetOKStatus() Status {
-	return Status{Status: okValue}
+	Status string `json:"status"`
 }
 
 func HandleAlive(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	body, err := json.Marshal(GetOKStatus())
-	if err != nil {
-		log.Printf("Error during Health Check Liveness Check\nerror: %s", err.Error())
-	}
+	body, _ := json.Marshal(Status{Status: okValue})
 	w.Write(body)
 	return
-}
-
-func HandleReady(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
-	body, err := json.Marshal(GetOKStatus())
-	if err != nil {
-		log.Printf("Error during Health Check Liveness Check\nerror: %s", err.Error())
-	}
-	w.Write(body)
-	return
-}
-
-func EmptyStatus() *Status {
-	return &Status{}
 }

--- a/health/health.go
+++ b/health/health.go
@@ -1,0 +1,97 @@
+package health
+
+//Notes on Thread safety: Currently we only expose methods that read the state of the singletons therefore thread safety is not an issue.
+//In case the scope of use case for Health expands: Implement RWLocks for the singleton variables, or implement using buffered channels to change state
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+)
+
+const okValue = "ok"
+
+var aliveSingleton Status
+var readySingleton Status
+
+type Status struct {
+	Status  string `json:"status"`
+	Message string `json:"message,omitempty"`
+}
+
+func getAlive() Status {
+	if aliveSingleton.Status == EmptyStatus().Status {
+		SetAlive()
+	}
+	return aliveSingleton
+}
+
+func getReady() Status {
+	if readySingleton.Status == EmptyStatus().Status {
+		SetReady()
+	}
+	return readySingleton
+}
+
+func SetUnAlive(msg string) {
+	aliveSingleton = Status{
+		Status:  http.StatusText(503),
+		Message: msg,
+	}
+}
+
+func SetUnReady(msg string) {
+	readySingleton = Status{
+		Status:  http.StatusText(503),
+		Message: msg,
+	}
+}
+
+func SetReady() {
+	readySingleton = Status{Status: okValue}
+}
+
+func SetAlive() {
+	aliveSingleton = Status{Status: okValue}
+}
+
+func HandleAlive(w http.ResponseWriter, r *http.Request) {
+	status := getAlive()
+	w.Header().Set("Content-Type", "application/json")
+	if status.Status == okValue {
+		w.WriteHeader(200)
+	} else {
+		w.WriteHeader(503)
+	}
+	body, err := json.Marshal(status)
+	if err != nil {
+		log.Printf("Error during Health Check Liveness Check\nerror: %s", err.Error())
+	}
+	w.Write(body)
+	return
+}
+
+func HandleReady(w http.ResponseWriter, r *http.Request) {
+	status := getReady()
+	w.Header().Set("Content-Type", "application/json")
+	if status.Status == okValue {
+		w.WriteHeader(200)
+	} else {
+		w.WriteHeader(503)
+	}
+	body, err := json.Marshal(status)
+	if err != nil {
+		log.Printf("Error during Health Check Readiness Check\nerror: %s", err.Error())
+	}
+	w.Write(body)
+	return
+}
+
+func EmptyStatus() *Status {
+	return &Status{}
+}
+
+func TestResetHealth() {
+	aliveSingleton = Status{}
+	readySingleton = Status{}
+}

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"embed"
 	"encoding/json"
 	"fmt"
+	"identity_platform_login_ui/health"
 	"io/fs"
 	"io/ioutil"
 	"log"
@@ -99,6 +100,7 @@ func main() {
 	http.HandleFunc("/api/kratos/self-service/login", handleUpdateFlow)
 	http.HandleFunc("/api/kratos/self-service/errors", handleKratosError)
 	http.HandleFunc("/api/consent", handleConsent)
+	http.HandleFunc("/health/alive", health.HandleAlive)
 
 	port := os.Getenv("PORT")
 

--- a/main_test.go
+++ b/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"identity_platform_login_ui/health"
 	handlers "identity_platform_login_ui/ory_mocking/Handlers"
 	testServers "identity_platform_login_ui/ory_mocking/Testservers"
 	"io"
@@ -27,6 +28,7 @@ const (
 	HANDLE_GET_LOGIN_FLOW_URL    = "/api/kratos/self-service/login/flows?id=1111"
 	HANDLE_ERROR_URL             = "/api/kratos/self-service/errors?id=1111"
 	HANDLE_CONSENT_URL           = "/api/consent?consent_challenge=test_challange"
+	HANDLE_ALIVE_URL             = "/health/alive"
 )
 
 // --------------------------------------------
@@ -312,4 +314,47 @@ func CreateGenericTest(t *testing.T, serverCreater func(t *testing.T), HttpMetho
 		return nil, err
 	}
 	return data, nil
+}
+
+// --------------------------------------------
+// TESTING HEALTH CHECK
+// --------------------------------------------
+func TestAliveOK(t *testing.T) {
+	health.TestResetHealth()
+	req := httptest.NewRequest(http.MethodGet, HANDLE_ALIVE_URL, nil)
+	w := httptest.NewRecorder()
+	health.HandleAlive(w, req)
+	res := w.Result()
+	defer res.Body.Close()
+	data, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		t.Errorf("expected error to be nil got %v", err)
+	}
+	recievedStatus := health.EmptyStatus()
+	if err := json.Unmarshal(data, recievedStatus); err != nil {
+		t.Errorf("expected error to be nil got %v", err)
+	}
+	assert.Equalf(t, "ok", recievedStatus.Status, "Expected %s, got %s", "ok", recievedStatus.Status)
+}
+
+func TestAliveFail(t *testing.T) {
+	health.TestResetHealth()
+	testMessage := "Liveness Check failed for test"
+	health.SetUnAlive(testMessage)
+
+	req := httptest.NewRequest(http.MethodGet, HANDLE_ALIVE_URL, nil)
+	w := httptest.NewRecorder()
+	health.HandleAlive(w, req)
+	res := w.Result()
+	defer res.Body.Close()
+	data, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		t.Errorf("expected error to be nil got %v", err)
+	}
+	recievedStatus := health.EmptyStatus()
+	if err := json.Unmarshal(data, recievedStatus); err != nil {
+		t.Errorf("expected error to be nil got %v", err)
+	}
+	assert.Equalf(t, http.StatusText(503), recievedStatus.Status, "Expected %s, got %s", http.StatusText(503), recievedStatus.Status)
+	assert.Equalf(t, testMessage, recievedStatus.Message, "Expected %s, got %s", testMessage, recievedStatus.Message)
 }

--- a/main_test.go
+++ b/main_test.go
@@ -329,7 +329,7 @@ func TestAliveOK(t *testing.T) {
 	if err != nil {
 		t.Errorf("expected error to be nil got %v", err)
 	}
-	receivedStatus := health.EmptyStatus()
+	receivedStatus := new(health.Status)
 	if err := json.Unmarshal(data, receivedStatus); err != nil {
 		t.Errorf("expected error to be nil got %v", err)
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -320,7 +320,6 @@ func CreateGenericTest(t *testing.T, serverCreater func(t *testing.T), HttpMetho
 // TESTING HEALTH CHECK
 // --------------------------------------------
 func TestAliveOK(t *testing.T) {
-	health.TestResetHealth()
 	req := httptest.NewRequest(http.MethodGet, HANDLE_ALIVE_URL, nil)
 	w := httptest.NewRecorder()
 	health.HandleAlive(w, req)
@@ -330,31 +329,9 @@ func TestAliveOK(t *testing.T) {
 	if err != nil {
 		t.Errorf("expected error to be nil got %v", err)
 	}
-	recievedStatus := health.EmptyStatus()
-	if err := json.Unmarshal(data, recievedStatus); err != nil {
+	receivedStatus := health.EmptyStatus()
+	if err := json.Unmarshal(data, receivedStatus); err != nil {
 		t.Errorf("expected error to be nil got %v", err)
 	}
-	assert.Equalf(t, "ok", recievedStatus.Status, "Expected %s, got %s", "ok", recievedStatus.Status)
-}
-
-func TestAliveFail(t *testing.T) {
-	health.TestResetHealth()
-	testMessage := "Liveness Check failed for test"
-	health.SetUnAlive(testMessage)
-
-	req := httptest.NewRequest(http.MethodGet, HANDLE_ALIVE_URL, nil)
-	w := httptest.NewRecorder()
-	health.HandleAlive(w, req)
-	res := w.Result()
-	defer res.Body.Close()
-	data, err := ioutil.ReadAll(res.Body)
-	if err != nil {
-		t.Errorf("expected error to be nil got %v", err)
-	}
-	recievedStatus := health.EmptyStatus()
-	if err := json.Unmarshal(data, recievedStatus); err != nil {
-		t.Errorf("expected error to be nil got %v", err)
-	}
-	assert.Equalf(t, http.StatusText(503), recievedStatus.Status, "Expected %s, got %s", http.StatusText(503), recievedStatus.Status)
-	assert.Equalf(t, testMessage, recievedStatus.Message, "Expected %s, got %s", testMessage, recievedStatus.Message)
+	assert.Equalf(t, "ok", receivedStatus.Status, "Expected %s, got %s", "ok", receivedStatus.Status)
 }

--- a/ory_mocking/Handlers/handlers.go
+++ b/ory_mocking/Handlers/handlers.go
@@ -62,6 +62,10 @@ type GenericError struct {
 	Status  string `json:"status"`
 }
 
+type Status struct {
+	Status string `json:"status"`
+}
+
 func GenericErrorConstructor(testname string) GenericError {
 	error := GenericError{
 		Code:    DEFAULT_ERROR_CODE,
@@ -229,5 +233,33 @@ func CreateHandlerWithError(testname string) func(w http.ResponseWriter, r *http
 
 func TimeoutHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusGatewayTimeout)
+	return
+}
+
+func GetOKStatus(w http.ResponseWriter, r *http.Request) {
+	status := Status{
+		Status: "ok",
+	}
+	jsonResp, err := json.Marshal(status)
+	if err != nil {
+		log.Printf("Bug in test handler: GetOKStatus\nerror: %s", err.Error())
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+	w.Write(jsonResp)
+	return
+}
+
+func GetErrorStatus(w http.ResponseWriter, r *http.Request) {
+	status := Status{
+		Status: http.StatusText(503),
+	}
+	jsonResp, err := json.Marshal(status)
+	if err != nil {
+		log.Printf("Bug in test handler: GetOKStatus\nerror: %s", err.Error())
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(503)
+	w.Write(jsonResp)
 	return
 }

--- a/ory_mocking/Testservers/testservers.go
+++ b/ory_mocking/Testservers/testservers.go
@@ -22,6 +22,8 @@ func createKratosMockServer() *httptest.Server {
 	mux.HandleFunc("/self-service/login/browser", handlers.SelfServiceLoginBrowserHandler)
 	mux.HandleFunc("/self-service/login/flows", handlers.SelfServiceGetLoginHandler)
 	mux.HandleFunc("/self-service/login", handlers.SelfServiceLoginHandler)
+	mux.HandleFunc("/health/alive", handlers.GetOKStatus)
+	mux.HandleFunc("/health/ready", handlers.GetOKStatus)
 
 	s := httptest.NewServer(mux)
 	os.Setenv("KRATOS_PUBLIC_URL", s.URL)
@@ -32,6 +34,8 @@ func createHydraMockServer() *httptest.Server {
 	mux.HandleFunc("/admin/oauth2/auth/requests/login/accept", handlers.Oauth2AuthRequestLoginAcceptHandler)
 	mux.HandleFunc("/admin/oauth2/auth/requests/consent", handlers.Oauth2AuthRequestConsentHandler)
 	mux.HandleFunc("/admin/oauth2/auth/requests/consent/accept", handlers.Oauth2AuthRequestConsentAcceptHandler)
+	mux.HandleFunc("/health/alive", handlers.GetOKStatus)
+	mux.HandleFunc("/health/ready", handlers.GetOKStatus)
 	s := httptest.NewServer(mux)
 	os.Setenv("HYDRA_ADMIN_URL", s.URL)
 	return s
@@ -73,6 +77,8 @@ func createKratosTimeoutMockServer() *httptest.Server {
 	mux.HandleFunc("/sessions/whoami", handlers.TimeoutHandler)
 	mux.HandleFunc("/self-service/login/browser", handlers.TimeoutHandler)
 	mux.HandleFunc("/self-service/login", handlers.TimeoutHandler)
+	mux.HandleFunc("/health/alive", handlers.TimeoutHandler)
+	mux.HandleFunc("/health/ready", handlers.TimeoutHandler)
 
 	s := httptest.NewServer(mux)
 	os.Setenv("KRATOS_PUBLIC_URL", s.URL+"/")
@@ -83,6 +89,8 @@ func createHydraTimeoutMockServer() *httptest.Server {
 	mux.HandleFunc("/admin/oauth2/auth/requests/login/accept", handlers.TimeoutHandler)
 	mux.HandleFunc("/admin/oauth2/auth/requests/consent", handlers.TimeoutHandler)
 	mux.HandleFunc("/admin/oauth2/auth/requests/consent/accept", handlers.TimeoutHandler)
+	mux.HandleFunc("/health/alive", handlers.TimeoutHandler)
+	mux.HandleFunc("/health/ready", handlers.TimeoutHandler)
 	s := httptest.NewServer(mux)
 	os.Setenv("HYDRA_ADMIN_URL", s.URL)
 	return s
@@ -102,6 +110,8 @@ func createKratosErrorMockServer() *httptest.Server {
 	mux.HandleFunc("/self-service/login/browser", handlers.CreateHandlerWithError("SelfServiceLoginBrowserHandler"))
 	mux.HandleFunc("/self-service/login/flows", handlers.CreateHandlerWithError("SelfServiceGetLoginHandler"))
 	mux.HandleFunc("/self-service/login", handlers.CreateHandlerWithError("SelfServiceLoginHandler"))
+	mux.HandleFunc("/health/alive", handlers.GetErrorStatus)
+	mux.HandleFunc("/health/ready", handlers.GetErrorStatus)
 
 	s := httptest.NewServer(mux)
 	os.Setenv("KRATOS_PUBLIC_URL", s.URL+"/")
@@ -112,6 +122,8 @@ func createHydraErrorMockServer() *httptest.Server {
 	mux.HandleFunc("/admin/oauth2/auth/requests/login/accept", handlers.CreateHandlerWithError("Oauth2AuthRequestLoginAcceptHandler"))
 	mux.HandleFunc("/admin/oauth2/auth/requests/consent", handlers.CreateHandlerWithError("Oauth2AuthRequestConsentHandler"))
 	mux.HandleFunc("/admin/oauth2/auth/requests/consent/accept", handlers.CreateHandlerWithError("Oauth2AuthRequestConsentAcceptHandler"))
+	mux.HandleFunc("/health/alive", handlers.GetErrorStatus)
+	mux.HandleFunc("/health/ready", handlers.GetErrorStatus)
 	s := httptest.NewServer(mux)
 	os.Setenv("HYDRA_ADMIN_URL", s.URL)
 	return s
@@ -121,4 +133,21 @@ func CreateErrorServers(t *testing.T) {
 	ehydra := createHydraErrorMockServer()
 	t.Cleanup(ekratos.Close)
 	t.Cleanup(ehydra.Close)
+}
+
+func ClearEnvars(t *testing.T) {
+	if _, ok := os.LookupEnv("HYDRA_ADMIN_URL"); ok {
+		err := os.Unsetenv("HYDRA_ADMIN_URL")
+		if err != nil {
+			t.Errorf("expected error to be nil got %v", err)
+		}
+	}
+	if _, ok := os.LookupEnv("KRATOS_PUBLIC_URL"); ok {
+		err := os.Unsetenv("KRATOS_PUBLIC_URL")
+		if err != nil {
+			t.Errorf("expected error to be nil got %v", err)
+		}
+	}
+
+	return
 }


### PR DESCRIPTION
The purpose of this PR is to implement a liveness check for Login UI. It is accessible on the endpoint /health/alive. If the server is running, liveness check returns with '{'status':'ok'}'.

The pr includes the health.go library that exposes the handler for the liveness check. It also includes a handler for a readiness check which is not used in main, and is only there for possible future usage.

The pr also includes unit tests for the liveness check.

Additionally the pr includes mocked health checks for the mocked ory servers used for unit tests.

- health library implementing an API to store alive and ready statuses independently
- main.go implementing liveness check only
- tests liveness checks
- Handlers for mocking health checks
- mocked servers implementing health check mocking

This pr replaces https://github.com/canonical/identity-platform-login-ui/pull/30