### PR TITLE
IAM 353

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -41,7 +41,7 @@ func main() {
 	logger := logging.NewLogger(specs.LogLevel, specs.LogFile)
 
 	monitor := prometheus.NewMonitor("identity-login-ui", logger)
-	tracer := tracing.NewTracer(tracing.NewConfig(specs.JaegerEndpoint, logger))
+	tracer := tracing.NewTracer(tracing.NewConfig(specs.TracingEnabled, specs.JaegerEndpoint, logger))
 
 	distFS, err := fs.Sub(jsFS, "ui/dist")
 

--- a/internal/config/specs.go
+++ b/internal/config/specs.go
@@ -3,6 +3,7 @@ package config
 // EnvSpec is the basic environment configuration setup needed for the app to start
 type EnvSpec struct {
 	JaegerEndpoint string `envconfig:"jaeger_endpoint"`
+	TracingEnabled bool   `envconfig:"tracing_enabled" default:"true"`
 
 	LogLevel string `envconfig:"log_level" default:"error"`
 	LogFile  string `envconfig:"log_file" default:"log.txt"`

--- a/internal/tracing/config.go
+++ b/internal/tracing/config.go
@@ -7,13 +7,16 @@ import (
 type Config struct {
 	JaegerEndpoint string
 	Logger         logging.LoggerInterface
+
+	Enabled bool
 }
 
-func NewConfig(endpoint string, logger logging.LoggerInterface) *Config {
+func NewConfig(enabled bool, endpoint string, logger logging.LoggerInterface) *Config {
 	c := new(Config)
 
 	c.JaegerEndpoint = endpoint
 	c.Logger = logger
+	c.Enabled = enabled
 
 	return c
 }

--- a/internal/tracing/tracer.go
+++ b/internal/tracing/tracer.go
@@ -82,6 +82,13 @@ func NewTracer(cfg *Config) *Tracer {
 
 	t.logger = cfg.Logger
 
+	// if tracing disabled skip the config
+	if !cfg.Enabled {
+		t.tracer = trace.NewNoopTracerProvider().Tracer("github.com/canonical/identity-platform-login-ui")
+
+		return t
+	}
+
 	var err error
 	var exporter sdktrace.SpanExporter
 


### PR DESCRIPTION
IAM-353: disable tracing via env var

- fix: IAM-353 - allow tracing to be disabled
- fix: add tracing enabling variable, defaulting to true



## BEFORE 

```
shipperizer in ~/shipperizer/identity-platform-login-ui on IAM-353 ● λ LOG_LEVEL=debug go run cmd/main.go
{"severity":"info","@timestamp":"2023-06-28T13:31:44.044403436+01:00","message":"Starting server on port 8080"}
{"severity":"debug","@timestamp":"2023-06-28T13:31:48.043094715+01:00","message":"[rifleman/aXNsY8CwkG-000001] GET http://localhost:8080/api/v0/metrics HTTP/1.1 from 127.0.0.1:39588 map[Content-Encoding:[gzip] Content-Type:[text/plain; version=0.0.4; charset=utf-8]] 200 1322B in 1.631823ms"}
{
	"Name": "server",
	"SpanContext": {
		"TraceID": "ea101bc8ecb64029c8ba2a2fb43b428a",
		"SpanID": "6670d2d5b09df461",
		"TraceFlags": "01",
		"TraceState": "",
		"Remote": false
	},
	"Parent": {
		"TraceID": "00000000000000000000000000000000",
		"SpanID": "0000000000000000",
		"TraceFlags": "00",
		"TraceState": "",
		"Remote": false
	},
	"SpanKind": 2,
	"StartTime": "2023-06-28T13:31:48.041421719+01:00",
	"EndTime": "2023-06-28T13:31:48.043303132+01:00",
	"Attributes": [
		{
			"Key": "http.method",
			"Value": {
				"Type": "STRING",
				"Value": "GET"
			}
		},

```

## AFTER

```
shipperizer in ~/shipperizer/identity-platform-login-ui on IAM-353 ● λ LOG_LEVEL=debug TRACING_ENABLED=0 go run cmd/main.go
{"severity":"info","@timestamp":"2023-06-28T13:31:57.460065184+01:00","message":"Starting server on port 8080"}
{"severity":"debug","@timestamp":"2023-06-28T13:31:59.236344075+01:00","message":"[rifleman/jR7AbMbJU6-000001] GET http://localhost:8080/api/v0/metrics HTTP/1.1 from 127.0.0.1:56828 map[Content-Encoding:[gzip] Content-Type:[text/plain; version=0.0.4; charset=utf-8]] 200 1313B in 2.580227ms"}




```