### PR TITLE
IAM-356: release/token

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,9 +2,7 @@ name: ci
 run-name: CI for ${{ github.sha }} on ${{ github.ref_name }}
 
 on:
-   create:
-     tags:
-     - "v**"
+   workflow_dispatch:
    push:
      branches:
      - "main"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,6 +18,7 @@ jobs:
           package-name: ""
           default-branch: main
           pull-request-title-pattern: "ci: release ${version}"
+          token: ${{ secrets.PAT_TOKEN }}
         id: release
       - uses: actions/checkout@v3
       - name: Workaround for https://github.com/googleapis/release-please/issues/922

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,6 +1,7 @@
 name: release
 
 on:
+  workflow_dispatch:
   push:
     branches:
     - main


### PR DESCRIPTION
IAM-356: use separate token to overcome gh action block on recursive wokrflow creation

- ci: allow manual triggering of workflows
- ci: use different token to create releases
