### PR TITLE
Change response status to 200

### DIFF
--- a/pkg/kratos/handlers.go
+++ b/pkg/kratos/handlers.go
@@ -53,7 +53,7 @@ func (a *API) handleCreateFlow(w http.ResponseWriter, r *http.Request) {
 		// The frontend will call this endpoint with an XHR request, so the status code is
 		// not that important (the redirect happens based on the response body). But we still send
 		// a redirect code response to be consistent with the hydra response.
-		http.Redirect(w, r, redirectTo.RedirectTo, http.StatusSeeOther)
+		w.WriteHeader(http.StatusOK)
 		w.Write(resp)
 		return
 	}

--- a/pkg/kratos/handlers_test.go
+++ b/pkg/kratos/handlers_test.go
@@ -140,10 +140,18 @@ func TestHandleCreateFlowWithSession(t *testing.T) {
 
 	res := w.Result()
 
-	if res.StatusCode != http.StatusSeeOther {
-		t.Fatal("Expected HTTP status code 303, got: ", res.Status)
+	data, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		t.Fatalf("Expected error to be nil got %v", err)
 	}
-	if res.Header["Location"][0] != redirect {
+	redirectResp := hClient.NewOAuth2RedirectToWithDefaults()
+	if err := json.Unmarshal(data, redirectResp); err != nil {
+		t.Fatalf("Expected error to be nil got %v", err)
+	}
+	if res.StatusCode != http.StatusOK {
+		t.Fatal("Expected HTTP status code 200, got: ", res.Status)
+	}
+	if redirectResp.RedirectTo != redirect {
 		t.Fatalf("Expected redirect to %s, got: %s", redirect, res.Header["Location"][0])
 	}
 }


### PR DESCRIPTION
The redirect response was causing the XHR request to fail because it would get redirected to Hydra and get a CORS error.