### PR TITLE
IAM-386-Fix-Route-Matching bug

### DIFF
--- a/pkg/ui/handlers.go
+++ b/pkg/ui/handlers.go
@@ -1,30 +1,36 @@
 package ui
 
 import (
+	"fmt"
 	"io/fs"
 	"net/http"
 	"path"
+	"strings"
 
 	"github.com/canonical/identity-platform-login-ui/internal/logging"
 	"github.com/go-chi/chi/v5"
 )
 
+const UI = "/ui"
+
 type API struct {
 	fileServer http.Handler
-
-	logger logging.LoggerInterface
+	logger     logging.LoggerInterface
 }
 
 func (a *API) RegisterEndpoints(mux *chi.Mux) {
 	// TODO @shipperizer unsure if we deal with any POST/PUT/PATCH via js
-	mux.HandleFunc("/*", a.uiFiles)
+	mux.HandleFunc(fmt.Sprintf("%s/*", UI), a.uiFiles)
+
 }
 
 // TODO: Validate response when server error handling is implemented
 func (a *API) uiFiles(w http.ResponseWriter, r *http.Request) {
-	if ext := path.Ext(r.URL.Path); ext == "" && r.URL.Path != "/" {
-		r.URL.Path += ".html"
+	if ext := path.Ext(r.URL.Path); ext == "" {
+		r.URL.Path = fmt.Sprintf("%s.html", r.URL.Path)
 	}
+
+	r.URL.Path = strings.TrimPrefix(r.URL.Path, UI)
 
 	a.fileServer.ServeHTTP(w, r)
 }

--- a/ui/api/hydra.ts
+++ b/ui/api/hydra.ts
@@ -3,7 +3,7 @@ import { Configuration, OAuth2Api } from "@ory/client";
 const hydraAdmin = new OAuth2Api(
   new Configuration({
     // Use relative path so that this works when served in a subpath
-    basePath: "./api/hydra",
+    basePath: "../api/hydra",
     baseOptions: {
       withCredentials: true,
     },

--- a/ui/api/kratos.ts
+++ b/ui/api/kratos.ts
@@ -3,7 +3,7 @@ import { Configuration, FrontendApi } from "@ory/client";
 export const kratos = new FrontendApi(
   new Configuration({
     // Use relative path so that this works when served in a subpath
-    basePath: "./api/kratos",
+    basePath: "../api/kratos",
     baseOptions: {
       withCredentials: true,
     },


### PR DESCRIPTION
Fixed bug, where the server treats all misc. routes as fileserver requests.

Try it out by compiling the app, and requesting different routes.

After that if you access /api/v0/metrics, you'll see that the server only added the .html extension to the routes corresponding to the embedded html files. 