### PR TITLE
IAM-398-Added deep health check

### DIFF
--- a/internal/hydra/client.go
+++ b/internal/hydra/client.go
@@ -15,6 +15,10 @@ func (c *Client) OAuth2Api() client.OAuth2Api {
 	return c.c.OAuth2Api
 }
 
+func (c *Client) MetadataApi() client.MetadataApi {
+	return c.c.MetadataApi
+}
+
 func NewClient(url string) *Client {
 	c := new(Client)
 

--- a/internal/kratos/client.go
+++ b/internal/kratos/client.go
@@ -15,6 +15,10 @@ func (c *Client) FrontendApi() client.FrontendApi {
 	return c.c.FrontendApi
 }
 
+func (c *Client) MetadataApi() client.MetadataApi {
+	return c.c.MetadataApi
+}
+
 func NewClient(url string) *Client {
 	c := new(Client)
 

--- a/pkg/status/handlers.go
+++ b/pkg/status/handlers.go
@@ -3,6 +3,7 @@ package status
 import (
 	"encoding/json"
 	"net/http"
+	"sync"
 
 	"github.com/canonical/identity-platform-login-ui/internal/logging"
 	"github.com/canonical/identity-platform-login-ui/internal/monitoring"
@@ -17,7 +18,14 @@ type Status struct {
 	BuildInfo *BuildInfo `json:"buildInfo"`
 }
 
+type DeepCheckStatus struct {
+	KratosStatus string `json:"kratos_status"`
+	HydraStatus  string `json:"hydra_status"`
+}
+
 type API struct {
+	service ServiceInterface
+
 	tracer trace.Tracer
 
 	monitor monitoring.MonitorInterface
@@ -27,7 +35,7 @@ type API struct {
 func (a *API) RegisterEndpoints(mux *chi.Mux) {
 	mux.Get("/api/v0/status", a.alive)
 	mux.Get("/api/v0/version", a.version)
-
+	mux.Get("/api/v0/deepcheck", a.deepCheck)
 }
 
 func (a *API) alive(w http.ResponseWriter, r *http.Request) {
@@ -38,7 +46,7 @@ func (a *API) alive(w http.ResponseWriter, r *http.Request) {
 		Status: okValue,
 	}
 
-	_, span := a.tracer.Start(r.Context(), "buildInfo")
+	_, span := a.tracer.Start(r.Context(), "status.API.alive")
 
 	if buildInfo := buildInfo(); buildInfo != nil {
 		rr.BuildInfo = buildInfo
@@ -63,9 +71,55 @@ func (a *API) version(w http.ResponseWriter, r *http.Request) {
 
 }
 
-func NewAPI(tracer trace.Tracer, monitor monitoring.MonitorInterface, logger logging.LoggerInterface) *API {
+func (a *API) deepCheck(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	wg := sync.WaitGroup{}
+	wg.Add(2)
+
+	kratosOK := false
+	hydraOK := false
+
+	go func() {
+		res, err := a.service.CheckKratosReady(r.Context())
+		if err != nil {
+			a.logger.Errorf("error when checking kratos status: %s", err)
+		}
+		kratosOK = res
+		wg.Done()
+	}()
+
+	go func() {
+		res, err := a.service.CheckHydraReady(r.Context())
+		if err != nil {
+			a.logger.Errorf("error when checking hydra status: %s", err)
+		}
+		hydraOK = res
+		wg.Done()
+	}()
+
+	wg.Wait()
+
+	msgMap := func(ok bool) string {
+		if ok {
+			return okValue
+		}
+		return "unavailable"
+	}
+
+	ds := DeepCheckStatus{
+		KratosStatus: msgMap(kratosOK),
+		HydraStatus:  msgMap(hydraOK),
+	}
+
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(ds)
+}
+
+func NewAPI(service ServiceInterface, tracer trace.Tracer, monitor monitoring.MonitorInterface, logger logging.LoggerInterface) *API {
 	a := new(API)
 
+	a.service = service
 	a.tracer = tracer
 	a.monitor = monitor
 	a.logger = logger

--- a/pkg/status/interfaces.go
+++ b/pkg/status/interfaces.go
@@ -1,0 +1,10 @@
+package status
+
+import (
+	"context"
+)
+
+type ServiceInterface interface {
+	CheckKratosReady(context.Context) (bool, error)
+	CheckHydraReady(context.Context) (bool, error)
+}

--- a/pkg/status/service.go
+++ b/pkg/status/service.go
@@ -1,0 +1,65 @@
+package status
+
+import (
+	"context"
+
+	"github.com/canonical/identity-platform-login-ui/internal/logging"
+	"github.com/canonical/identity-platform-login-ui/internal/monitoring"
+	"go.opentelemetry.io/otel/trace"
+
+	hClient "github.com/ory/hydra-client-go/v2"
+	kClient "github.com/ory/kratos-client-go"
+)
+
+type Service struct {
+	kratos kClient.MetadataApi
+	hydra  hClient.MetadataApi
+
+	tracer  trace.Tracer
+	monitor monitoring.MonitorInterface
+	logger  logging.LoggerInterface
+}
+
+func (s *Service) CheckKratosReady(ctx context.Context) (bool, error) {
+	ctx, span := s.tracer.Start(ctx, "status.Service.CheckKratosReady")
+	defer span.End()
+
+	_, r, err := s.kratos.IsReady(ctx).Execute()
+
+	if err != nil {
+		s.logger.Error(err)
+		s.logger.Debugf("full HTTP response: %v", r)
+
+	}
+
+	return err == nil, err
+
+}
+
+func (s *Service) CheckHydraReady(ctx context.Context) (bool, error) {
+	ctx, span := s.tracer.Start(ctx, "status.Service.CheckHydraReady")
+	defer span.End()
+
+	_, r, err := s.hydra.IsReady(ctx).Execute()
+
+	if err != nil {
+		s.logger.Error(err)
+		s.logger.Debugf("full HTTP response: %v", r)
+	}
+
+	return err == nil, err
+
+}
+
+func NewService(kmeta kClient.MetadataApi, hmeta hClient.MetadataApi, tracer trace.Tracer, monitor monitoring.MonitorInterface, logger logging.LoggerInterface) *Service {
+	s := new(Service)
+
+	s.kratos = kmeta
+	s.hydra = hmeta
+
+	s.monitor = monitor
+	s.tracer = tracer
+	s.logger = logger
+
+	return s
+}

--- a/pkg/status/service_test.go
+++ b/pkg/status/service_test.go
@@ -1,0 +1,178 @@
+package status
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/canonical/identity-platform-login-ui/internal/monitoring"
+	"github.com/golang/mock/gomock"
+
+	hClient "github.com/ory/hydra-client-go/v2"
+	kClient "github.com/ory/kratos-client-go"
+	"go.opentelemetry.io/otel/trace"
+)
+
+//go:generate mockgen -build_flags=--mod=mod -package status -destination ./mock_logger.go -source=../../internal/logging/interfaces.go
+//go:generate mockgen -build_flags=--mod=mod -package status -destination ./mock_status.go -source=./interfaces.go
+//go:generate mockgen -build_flags=--mod=mod -package status -destination ./mock_monitor.go -source=../../internal/monitoring/interfaces.go
+//go:generate mockgen -build_flags=--mod=mod -package status -destination ./mock_tracing.go go.opentelemetry.io/otel/trace Tracer
+//go:generate mockgen -build_flags=--mod=mod -package status -destination ./mock_kratos.go github.com/ory/kratos-client-go MetadataApi
+//go:generate mockgen -build_flags=--mod=mod -package status -destination ./mock_hydra.go -mock_names MetadataApi=MockHydraMetadataApi "github.com/ory/hydra-client-go/v2" MetadataApi
+
+func TestCheckKratosReadySuccess(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := monitoring.NewMockMonitorInterface(ctrl)
+	mockKratosMetadataApi := NewMockMetadataApi(ctrl)
+	mockHydraMetadataApi := NewMockHydraMetadataApi(ctrl)
+
+	ctx := context.Background()
+
+	isReadyReturn := kClient.MetadataApiIsReadyRequest{
+		ApiService: mockKratosMetadataApi,
+	}
+
+	mockTracer.EXPECT().Start(ctx, "status.Service.CheckKratosReady").Times(1).Return(ctx, trace.SpanFromContext(ctx))
+
+	mockKratosMetadataApi.EXPECT().IsReady(ctx).Times(1).Return(isReadyReturn)
+
+	mockKratosMetadataApi.EXPECT().IsReadyExecute(gomock.Any()).Times(1).DoAndReturn(
+		func(r kClient.MetadataApiIsReadyRequest) (*kClient.IsAlive200Response, *http.Response, error) {
+			isAlive := kClient.NewIsAlive200ResponseWithDefaults()
+			httpResp := new(http.Response)
+			httpResp.StatusCode = 200
+			return isAlive, httpResp, nil
+		},
+	)
+
+	r, _ := NewService(mockKratosMetadataApi, mockHydraMetadataApi, mockTracer, mockMonitor, mockLogger).CheckKratosReady(ctx)
+
+	if !r {
+		t.Fatalf("expected response to be %v not  %v", true, false)
+	}
+}
+
+func TestCheckHydraReadySuccess(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := monitoring.NewMockMonitorInterface(ctrl)
+	mockKratosMetadataApi := NewMockMetadataApi(ctrl)
+	mockHydraMetadataApi := NewMockHydraMetadataApi(ctrl)
+
+	ctx := context.Background()
+
+	isReadyReturn := hClient.MetadataApiIsReadyRequest{
+		ApiService: mockHydraMetadataApi,
+	}
+
+	mockTracer.EXPECT().Start(ctx, "status.Service.CheckHydraReady").Times(1).Return(ctx, trace.SpanFromContext(ctx))
+
+	mockHydraMetadataApi.EXPECT().IsReady(gomock.Any()).Times(1).Return(isReadyReturn)
+
+	mockHydraMetadataApi.EXPECT().IsReadyExecute(gomock.Any()).Times(1).DoAndReturn(
+		func(r hClient.MetadataApiIsReadyRequest) (*hClient.IsReady200Response, *http.Response, error) {
+			isReady := hClient.NewIsReady200ResponseWithDefaults()
+			httpResp := new(http.Response)
+			httpResp.StatusCode = 200
+			return isReady, httpResp, nil
+		},
+	)
+
+	r, _ := NewService(mockKratosMetadataApi, mockHydraMetadataApi, mockTracer, mockMonitor, mockLogger).CheckHydraReady(ctx)
+
+	if !r {
+		t.Fatalf("expected response to be %v not  %v", true, false)
+	}
+}
+
+func TestCheckKratosReadyFailure(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := monitoring.NewMockMonitorInterface(ctrl)
+	mockKratosMetadataApi := NewMockMetadataApi(ctrl)
+	mockHydraMetadataApi := NewMockHydraMetadataApi(ctrl)
+
+	ctx := context.Background()
+
+	isReadyReturn := kClient.MetadataApiIsReadyRequest{
+		ApiService: mockKratosMetadataApi,
+	}
+
+	mockTracer.EXPECT().Start(ctx, "status.Service.CheckKratosReady").Times(1).Return(ctx, trace.SpanFromContext(ctx))
+
+	mockKratosMetadataApi.EXPECT().IsReady(ctx).Times(1).Return(isReadyReturn)
+
+	mockKratosMetadataApi.EXPECT().IsReadyExecute(gomock.Any()).Times(1).DoAndReturn(
+		func(r kClient.MetadataApiIsReadyRequest) (*kClient.IsAlive200Response, *http.Response, error) {
+			httpResp := new(http.Response)
+			httpResp.StatusCode = 500
+			return nil, httpResp, errors.New("Test Error")
+		},
+	)
+
+	mockLogger.EXPECT().Debugf(gomock.Any(), gomock.Any())
+	mockLogger.EXPECT().Error(gomock.Any())
+
+	r, err := NewService(mockKratosMetadataApi, mockHydraMetadataApi, mockTracer, mockMonitor, mockLogger).CheckKratosReady(ctx)
+
+	if r {
+		t.Fatalf("expected response to be %v not  %v", false, true)
+	}
+
+	if err == nil {
+		t.Fatal("expected error to not be nil")
+	}
+}
+
+func TestCheckHydraReadyFailure(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := monitoring.NewMockMonitorInterface(ctrl)
+	mockKratosMetadataApi := NewMockMetadataApi(ctrl)
+	mockHydraMetadataApi := NewMockHydraMetadataApi(ctrl)
+
+	ctx := context.Background()
+
+	isReadyReturn := hClient.MetadataApiIsReadyRequest{
+		ApiService: mockHydraMetadataApi,
+	}
+
+	mockTracer.EXPECT().Start(ctx, "status.Service.CheckHydraReady").Times(1).Return(ctx, trace.SpanFromContext(ctx))
+
+	mockHydraMetadataApi.EXPECT().IsReady(gomock.Any()).Times(1).Return(isReadyReturn)
+
+	mockHydraMetadataApi.EXPECT().IsReadyExecute(gomock.Any()).Times(1).DoAndReturn(
+		func(r hClient.MetadataApiIsReadyRequest) (*hClient.IsReady200Response, *http.Response, error) {
+			httpResp := new(http.Response)
+			httpResp.StatusCode = 500
+			return nil, httpResp, errors.New("Test Error")
+		},
+	)
+
+	mockLogger.EXPECT().Debugf(gomock.Any(), gomock.Any())
+	mockLogger.EXPECT().Error(gomock.Any())
+
+	r, err := NewService(mockKratosMetadataApi, mockHydraMetadataApi, mockTracer, mockMonitor, mockLogger).CheckHydraReady(ctx)
+
+	if r {
+		t.Fatalf("expected response to be %v not  %v", false, true)
+	}
+
+	if err == nil {
+		t.Fatal("expected error to not be nil")
+	}
+}

--- a/pkg/web/router.go
+++ b/pkg/web/router.go
@@ -50,7 +50,12 @@ func NewRouter(kratosClient *ik.Client, hydraClient *ih.Client, distFS fs.FS, ba
 		extra.NewService(kratosClient, hydraClient, tracer, monitor, logger),
 		logger,
 	).RegisterEndpoints(router)
-	status.NewAPI(tracer, monitor, logger).RegisterEndpoints(router)
+	status.NewAPI(
+		status.NewService(kratosClient.MetadataApi(), hydraClient.MetadataApi(), tracer, monitor, logger),
+		tracer,
+		monitor,
+		logger,
+	).RegisterEndpoints(router)
 	ui.NewAPI(distFS, logger).RegisterEndpoints(router)
 	metrics.NewAPI(logger).RegisterEndpoints(router)
 


### PR DESCRIPTION
Added the deep health check feature:

To manually test:
- Compile and run app with valid envvars for PORT, KRATOS_PUBLIC_URL, HYDRA_ADMIN_URL
- For urls use format: http://ip:port
- Send get request to the endpoint /api/v0/deepcheck