### PR TITLE
Cardinality reduction for Prometheus metrics

### DIFF
--- a/internal/http_meta/interfaces.go
+++ b/internal/http_meta/interfaces.go
@@ -1,0 +1,11 @@
+package http_meta
+
+import "net/http"
+
+type RestInterface interface {
+	Get(string, http.HandlerFunc)
+	Put(string, http.HandlerFunc)
+	Post(string, http.HandlerFunc)
+	Delete(string, http.HandlerFunc)
+	HandleFunc(string, http.HandlerFunc)
+}

--- a/internal/http_meta/registermux.go
+++ b/internal/http_meta/registermux.go
@@ -1,0 +1,47 @@
+package http_meta
+
+import (
+	"net/http"
+
+	"github.com/canonical/identity-platform-login-ui/internal/monitoring"
+	chi "github.com/go-chi/chi/v5"
+)
+
+type RegisterMux struct {
+	router  *chi.Mux
+	monitor monitoring.MonitorInterface
+}
+
+func (rmx *RegisterMux) Delete(pattern string, handlerFn http.HandlerFunc) {
+	rmx.monitor.RegisterEndpoints(pattern)
+	rmx.router.Delete(pattern, handlerFn)
+}
+func (rmx *RegisterMux) Get(pattern string, handlerFn http.HandlerFunc) {
+	rmx.monitor.RegisterEndpoints(pattern)
+	rmx.router.Get(pattern, handlerFn)
+}
+func (rmx *RegisterMux) Post(pattern string, handlerFn http.HandlerFunc) {
+	rmx.monitor.RegisterEndpoints(pattern)
+	rmx.router.Post(pattern, handlerFn)
+}
+func (rmx *RegisterMux) Put(pattern string, handlerFn http.HandlerFunc) {
+	rmx.monitor.RegisterEndpoints(pattern)
+	rmx.router.Put(pattern, handlerFn)
+}
+
+func (rmx *RegisterMux) HandleFunc(pattern string, handlerFn http.HandlerFunc) {
+	rmx.router.HandleFunc(pattern, handlerFn)
+}
+
+func (rmx *RegisterMux) GetMux() *chi.Mux {
+	return rmx.router
+}
+
+func NewRegisterMux(mux *chi.Mux, monitor monitoring.MonitorInterface) *RegisterMux {
+	router := RegisterMux{
+		router:  mux,
+		monitor: monitor,
+	}
+
+	return &router
+}

--- a/internal/monitoring/interfaces.go
+++ b/internal/monitoring/interfaces.go
@@ -3,6 +3,8 @@ package monitoring
 type MonitorInterface interface {
 	GetService() string
 	GetResponseTimeMetric(map[string]string) (MetricInterface, error)
+	RegisterEndpoints(...string)
+	VerifyEndpoint(string) bool
 }
 
 type MetricInterface interface {

--- a/internal/monitoring/middlewares_test.go
+++ b/internal/monitoring/middlewares_test.go
@@ -39,6 +39,7 @@ func TestMiddlewareResponseTime(t *testing.T) {
 	mockLogger := NewMockLoggerInterface(ctrl)
 	mockMonitor.EXPECT().GetService().Times(1)
 	mockMonitor.EXPECT().GetResponseTimeMetric(gomock.Any()).Times(1).Return(mockMetric, nil)
+	mockMonitor.EXPECT().VerifyEndpoint(gomock.Any()).Times(1).Return(true)
 	mockMetric.EXPECT().Observe(gomock.Any()).Times(1)
 
 	assert := assert.New(t)

--- a/internal/monitoring/prometheus/prometheus.go
+++ b/internal/monitoring/prometheus/prometheus.go
@@ -14,6 +14,8 @@ type Monitor struct {
 	responseTime *prometheus.HistogramVec
 
 	logger logging.LoggerInterface
+
+	validEndpoints map[string]struct{}
 }
 
 func (m *Monitor) GetService() string {
@@ -60,6 +62,18 @@ func (m *Monitor) registerHistograms() {
 	}
 }
 
+func (m *Monitor) RegisterEndpoints(endpoints ...string) {
+	for _, e := range endpoints {
+		m.validEndpoints[e] = struct{}{}
+	}
+}
+
+func (m *Monitor) VerifyEndpoint(endpoint string) bool {
+	_, ok := m.validEndpoints[endpoint]
+
+	return ok
+}
+
 func NewMonitor(service string, logger logging.LoggerInterface) *Monitor {
 	m := new(Monitor)
 
@@ -67,6 +81,8 @@ func NewMonitor(service string, logger logging.LoggerInterface) *Monitor {
 	m.logger = logger
 
 	m.registerHistograms()
+
+	m.validEndpoints = make(map[string]struct{})
 
 	return m
 }

--- a/pkg/extra/handlers.go
+++ b/pkg/extra/handlers.go
@@ -3,8 +3,8 @@ package extra
 import (
 	"net/http"
 
+	"github.com/canonical/identity-platform-login-ui/internal/http_meta"
 	"github.com/canonical/identity-platform-login-ui/internal/logging"
-	"github.com/go-chi/chi/v5"
 )
 
 type API struct {
@@ -13,7 +13,7 @@ type API struct {
 	logger logging.LoggerInterface
 }
 
-func (a *API) RegisterEndpoints(mux *chi.Mux) {
+func (a *API) RegisterEndpoints(mux http_meta.RestInterface) {
 	mux.Get("/api/consent", a.handleConsent)
 }
 

--- a/pkg/kratos/handlers.go
+++ b/pkg/kratos/handlers.go
@@ -9,8 +9,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/canonical/identity-platform-login-ui/internal/http_meta"
 	"github.com/canonical/identity-platform-login-ui/internal/logging"
-	"github.com/go-chi/chi/v5"
 )
 
 type API struct {
@@ -20,7 +20,7 @@ type API struct {
 	logger logging.LoggerInterface
 }
 
-func (a *API) RegisterEndpoints(mux *chi.Mux) {
+func (a *API) RegisterEndpoints(mux http_meta.RestInterface) {
 	mux.Post("/api/kratos/self-service/login", a.handleUpdateFlow)
 	mux.Get("/api/kratos/self-service/login/browser", a.handleCreateFlow)
 	mux.Get("/api/kratos/self-service/login/flows", a.handleGetLoginFlow)

--- a/pkg/metrics/handlers.go
+++ b/pkg/metrics/handlers.go
@@ -3,8 +3,8 @@ package metrics
 import (
 	"net/http"
 
+	"github.com/canonical/identity-platform-login-ui/internal/http_meta"
 	"github.com/canonical/identity-platform-login-ui/internal/logging"
-	"github.com/go-chi/chi/v5"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
@@ -12,7 +12,7 @@ type API struct {
 	logger logging.LoggerInterface
 }
 
-func (a *API) RegisterEndpoints(mux *chi.Mux) {
+func (a *API) RegisterEndpoints(mux http_meta.RestInterface) {
 	mux.Get("/api/v0/metrics", a.prometheusHTTP)
 }
 

--- a/pkg/status/handlers.go
+++ b/pkg/status/handlers.go
@@ -7,9 +7,9 @@ import (
 	"sync"
 	"time"
 
+	"github.com/canonical/identity-platform-login-ui/internal/http_meta"
 	"github.com/canonical/identity-platform-login-ui/internal/logging"
 	"github.com/canonical/identity-platform-login-ui/internal/monitoring"
-	"github.com/go-chi/chi/v5"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -34,7 +34,7 @@ type API struct {
 	logger  logging.LoggerInterface
 }
 
-func (a *API) RegisterEndpoints(mux *chi.Mux) {
+func (a *API) RegisterEndpoints(mux http_meta.RestInterface) {
 	mux.Get("/api/v0/status", a.alive)
 	mux.Get("/api/v0/version", a.version)
 	mux.Get("/api/v0/deepcheck", a.deepCheck)


### PR DESCRIPTION
In the current implementation, all requested route results in a separate http_response_time_seconds metric. This PR implements replacing the value of the route label of metrics belonging to requests with an invalid endpoint with unknown. 