### PR TITLE
Tranform Kratos 422 HTTP resp to 200

### DIFF
--- a/pkg/kratos/handlers.go
+++ b/pkg/kratos/handlers.go
@@ -137,7 +137,9 @@ func (a *API) handleUpdateFlow(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	setCookies(w, cookies)
-	w.WriteHeader(422)
+	// Kratos returns us a '422' response but we tranform it to a '200',
+	// because this is the expected behavior for us.
+	w.WriteHeader(200)
 	w.Write(resp)
 }
 

--- a/pkg/kratos/handlers.go
+++ b/pkg/kratos/handlers.go
@@ -86,7 +86,7 @@ func (a *API) handleCreateFlow(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	setCookies(w, cookies)
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	w.Write(resp)
 }
 
@@ -108,7 +108,7 @@ func (a *API) handleGetLoginFlow(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	setCookies(w, cookies)
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	w.Write(resp)
 }
 
@@ -139,7 +139,7 @@ func (a *API) handleUpdateFlow(w http.ResponseWriter, r *http.Request) {
 	setCookies(w, cookies)
 	// Kratos returns us a '422' response but we tranform it to a '200',
 	// because this is the expected behavior for us.
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	w.Write(resp)
 }
 
@@ -162,7 +162,7 @@ func (a *API) handleKratosError(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	setCookies(w, cookies)
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	w.Write(resp)
 }
 

--- a/pkg/kratos/handlers_test.go
+++ b/pkg/kratos/handlers_test.go
@@ -272,8 +272,8 @@ func TestHandleUpdateFlow(t *testing.T) {
 
 	flowId := "test"
 	redirectTo := "https://some/path/to/somewhere"
-	flow := new(ErrorBrowserLocationChangeRequired)
-	flow.RedirectBrowserTo = &redirectTo
+	flow := new(BrowserLocationChangeRequired)
+	flow.RedirectTo = &redirectTo
 
 	flowBody := new(kClient.UpdateLoginFlowBody)
 	flowBody.UpdateLoginFlowWithOidcMethod = kClient.NewUpdateLoginFlowWithOidcMethod("oidc", "oidc")
@@ -294,8 +294,8 @@ func TestHandleUpdateFlow(t *testing.T) {
 
 	res := w.Result()
 
-	if res.StatusCode != http.StatusUnprocessableEntity {
-		t.Fatal("Expected HTTP status code 422, got: ", res.Status)
+	if res.StatusCode != http.StatusOK {
+		t.Fatal("Expected HTTP status code 200, got: ", res.Status)
 	}
 
 	data, err := ioutil.ReadAll(res.Body)

--- a/pkg/kratos/interfaces.go
+++ b/pkg/kratos/interfaces.go
@@ -21,7 +21,7 @@ type ServiceInterface interface {
 	AcceptLoginRequest(context.Context, string, string) (*hClient.OAuth2RedirectTo, []*http.Cookie, error)
 	CreateBrowserLoginFlow(context.Context, string, string, string, bool, []*http.Cookie) (*kClient.LoginFlow, []*http.Cookie, error)
 	GetLoginFlow(context.Context, string, []*http.Cookie) (*kClient.LoginFlow, []*http.Cookie, error)
-	UpdateOIDCLoginFlow(context.Context, string, kClient.UpdateLoginFlowBody, []*http.Cookie) (*ErrorBrowserLocationChangeRequired, []*http.Cookie, error)
+	UpdateOIDCLoginFlow(context.Context, string, kClient.UpdateLoginFlowBody, []*http.Cookie) (*BrowserLocationChangeRequired, []*http.Cookie, error)
 	GetFlowError(context.Context, string) (*kClient.FlowError, []*http.Cookie, error)
 	ParseLoginFlowMethodBody(*http.Request) (*kClient.UpdateLoginFlowBody, error)
 }

--- a/pkg/kratos/service_test.go
+++ b/pkg/kratos/service_test.go
@@ -463,8 +463,8 @@ func TestUpdateLoginFlowSuccess(t *testing.T) {
 
 	f, c, err := NewService(mockKratos, mockHydra, mockTracer, mockMonitor, mockLogger).UpdateOIDCLoginFlow(ctx, flowId, *body, cookies)
 
-	if !reflect.DeepEqual(*f, flow) {
-		t.Fatalf("expected flow to be %+v not %+v", flow, *f)
+	if *f.RedirectTo != *flow.RedirectBrowserTo {
+		t.Fatalf("expected redirectTo to be %s not %s", *flow.RedirectBrowserTo, *f.RedirectTo)
 	}
 	if !reflect.DeepEqual(c, resp.Cookies()) {
 		t.Fatalf("expected cookies to be %v not  %v", resp.Cookies(), c)

--- a/ui/pages/login.tsx
+++ b/ui/pages/login.tsx
@@ -77,7 +77,11 @@ const Login: NextPage = () => {
           updateLoginFlowBody: values,
         })
         // We logged in successfully! Let's bring the user home.
-        .then(async () => {
+        .then(async ({ data }) => {
+          if ("redirect_to" in data) {
+            window.location.href = data.redirect_to as string;
+            return;
+          }
           if (flow?.return_to) {
             window.location.href = flow.return_to;
             return;


### PR DESCRIPTION
IAM-349:
- Convert Kratos 422 responses to  200 in the `UpdateLoginFlow` endpoint.
- Update the UI to handle the new response.