### PR TITLE
Expose app version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,7 @@ jobs:
           token: ${{ secrets.PAT_TOKEN }}
           extra-files: |
             rockcraft.yaml
-            internal/config/version.go
+            internal/version/const.go
         id: release
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4
       - name: Workaround for https://github.com/googleapis/release-please/issues/922

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,6 +20,7 @@ jobs:
           token: ${{ secrets.PAT_TOKEN }}
           extra-files: |
             rockcraft.yaml
+            internal/config/version.go
         id: release
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4
       - name: Workaround for https://github.com/googleapis/release-please/issues/922

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -40,6 +40,11 @@ func main() {
 
 	flags := config.NewFlags()
 
+	if flags.ShowVersion {
+		fmt.Printf("App Version: %s\n", config.Version)
+		os.Exit(0)
+	}
+
 	logger := logging.NewLogger(specs.LogLevel, specs.LogFile)
 
 	logger.Debugf("env vars: %v", specs)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -38,6 +38,8 @@ func main() {
 		panic(fmt.Errorf("issues with environment sourcing: %s", err))
 	}
 
+	flags := config.NewFlags()
+
 	logger := logging.NewLogger(specs.LogLevel, specs.LogFile)
 
 	logger.Debugf("env vars: %v", specs)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/canonical/identity-platform-login-ui/internal/logging"
 	"github.com/canonical/identity-platform-login-ui/internal/monitoring/prometheus"
 	"github.com/canonical/identity-platform-login-ui/internal/tracing"
+	"github.com/canonical/identity-platform-login-ui/internal/version"
 	"github.com/canonical/identity-platform-login-ui/pkg/web"
 )
 
@@ -42,7 +43,7 @@ func main() {
 
 	switch {
 	case flags.ShowVersion:
-		fmt.Printf("App Version: %s\n", config.Version)
+		fmt.Printf("App Version: %s\n", version.Version)
 		os.Exit(0)
 	default:
 		break

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -40,9 +40,12 @@ func main() {
 
 	flags := config.NewFlags()
 
-	if flags.ShowVersion {
+	switch {
+	case flags.ShowVersion:
 		fmt.Printf("App Version: %s\n", config.Version)
 		os.Exit(0)
+	default:
+		break
 	}
 
 	logger := logging.NewLogger(specs.LogLevel, specs.LogFile)

--- a/internal/config/specs.go
+++ b/internal/config/specs.go
@@ -1,5 +1,7 @@
 package config
 
+import "flag"
+
 // EnvSpec is the basic environment configuration setup needed for the app to start
 type EnvSpec struct {
 	OtelGRPCEndpoint string `envconfig:"otel_grpc_endpoint"`
@@ -15,4 +17,17 @@ type EnvSpec struct {
 
 	KratosPublicURL string `envconfig:"kratos_public_url"`
 	HydraAdminURL   string `envconfig:"hydra_admin_url"`
+}
+
+type Flags struct {
+	ShowVersion bool
+}
+
+func NewFlags() *Flags {
+	f := new(Flags)
+
+	flag.BoolVar(&f.ShowVersion, "version", false, "Show the app version")
+	flag.Parse()
+
+	return f
 }

--- a/internal/config/specs.go
+++ b/internal/config/specs.go
@@ -26,7 +26,7 @@ type Flags struct {
 func NewFlags() *Flags {
 	f := new(Flags)
 
-	flag.BoolVar(&f.ShowVersion, "version", false, "Show the app version")
+	flag.BoolVar(&f.ShowVersion, "version", false, "Show the app version and exit")
 	flag.Parse()
 
 	return f

--- a/internal/config/version.go
+++ b/internal/config/version.go
@@ -1,3 +1,3 @@
 package config
 
-var Version = "0.11.1"
+var Version = "0.11.1" // x-release-please-version

--- a/internal/config/version.go
+++ b/internal/config/version.go
@@ -1,0 +1,3 @@
+package config
+
+var Version = "0.11.1"

--- a/internal/config/version.go
+++ b/internal/config/version.go
@@ -1,3 +1,0 @@
-package config
-
-var Version = "0.11.1" // x-release-please-version

--- a/internal/version/const.go
+++ b/internal/version/const.go
@@ -1,0 +1,3 @@
+package version
+
+const Version = "v0.11.0" // x-release-please-version

--- a/pkg/status/service.go
+++ b/pkg/status/service.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"runtime/debug"
 
-	"github.com/canonical/identity-platform-login-ui/internal/config"
 	"github.com/canonical/identity-platform-login-ui/internal/healthcheck"
 	"github.com/canonical/identity-platform-login-ui/internal/logging"
 	"github.com/canonical/identity-platform-login-ui/internal/monitoring"
+	"github.com/canonical/identity-platform-login-ui/internal/version"
 	"go.opentelemetry.io/otel/trace"
 
 	hClient "github.com/ory/hydra-client-go/v2"
@@ -44,7 +44,7 @@ func (s *Service) BuildInfo(ctx context.Context) *BuildInfo {
 
 	buildInfo := new(BuildInfo)
 	buildInfo.Name = info.Main.Path
-	buildInfo.Version = config.Version
+	buildInfo.Version = version.Version
 	buildInfo.CommitHash = s.gitRevision(ctx, info.Settings)
 
 	return buildInfo

--- a/pkg/status/service.go
+++ b/pkg/status/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"runtime/debug"
 
+	"github.com/canonical/identity-platform-login-ui/internal/config"
 	"github.com/canonical/identity-platform-login-ui/internal/healthcheck"
 	"github.com/canonical/identity-platform-login-ui/internal/logging"
 	"github.com/canonical/identity-platform-login-ui/internal/monitoring"
@@ -14,8 +15,9 @@ import (
 )
 
 type BuildInfo struct {
-	Version string `json:"version"`
-	Name    string `json:"name"`
+	Version    string `json:"version"`
+	CommitHash string `json:"commit_hash"`
+	Name       string `json:"name"`
 }
 
 type Service struct {
@@ -42,7 +44,8 @@ func (s *Service) BuildInfo(ctx context.Context) *BuildInfo {
 
 	buildInfo := new(BuildInfo)
 	buildInfo.Name = info.Main.Path
-	buildInfo.Version = s.gitRevision(ctx, info.Settings)
+	buildInfo.Version = config.Version
+	buildInfo.CommitHash = s.gitRevision(ctx, info.Settings)
 
 	return buildInfo
 }


### PR DESCRIPTION
IAM-494

This PR:
- Adds CLI flags to the app
- Allows to inject the app version via ldflags
- Updates the status endpoint with information about the git commit hash

```console
$ APP_VERSION=42 make build 
make -C cmd build
make[1]: Entering directory '/home/nikos/projects/identity-platform-login-ui/cmd'
go build -ldflags "-X github.com/canonical/identity-platform-login-ui/internal/config.Version=42" -o app ./
make[1]: Leaving directory '/home/nikos/projects/identity-platform-login-ui/cmd'
$ ./cmd/app -version
App Version: 42
```

![image](https://github.com/canonical/identity-platform-login-ui/assets/19745916/e2c41c5f-9755-4364-80ea-beef4121e31a)
