### PR TITLE
Device flow POC

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -85,7 +85,7 @@ func serve() {
 		panic("Invalid authorization model provided")
 	}
 
-	router := web.NewRouter(kClient, hClient, authorizer, distFS, specs.BaseURL, tracer, monitor, logger)
+	router := web.NewRouter(kClient, hClient, authorizer, specs.HydraAdminURL, distFS, specs.BaseURL, tracer, monitor, logger)
 
 	logger.Infof("Starting server on port %v", specs.Port)
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -14,15 +14,14 @@ services:
         target: /etc/config/kratos
     command: -c /etc/config/kratos/kratos.yml migrate sql -e --yes
     restart: on-failure
-    networks:
-      - intranet
+    network_mode: "host"
   kratos:
     depends_on:
       - kratos-migrate
     image: oryd/kratos:v1.0.0
-    ports:
-      - '4433:4433' # public
-      - '4434:4434' # admin
+    # ports:
+    #   - '4433:4433' # public
+    #   - '4434:4434' # admin
     restart: unless-stopped
     environment:
       - DSN=sqlite:///var/lib/sqlite/db.sqlite?_fk=true
@@ -38,37 +37,38 @@ services:
       - type: bind
         source: ./docker/kratos
         target: /etc/config/kratos
-    networks:
-      - intranet
+    network_mode: "host"
     extra_hosts:
       - "host.docker.internal:host-gateway"
-  hydra:
-    image: hydra:latest
-    ports:
-      - "4444:4444" # Public port
-      - "4445:4445" # Admin port
-    volumes:
-      - type: volume
-        source: hydra-sqlite
-        target: /var/lib/sqlite
-        read_only: false
-      - type: bind
-        source: ./docker/hydra
-        target: /etc/config/hydra
-    environment:
-      - DSN=postgresql://hydra:hydra@postgres/hydra?sslmode=disable
-      - CORS_DEBUG=1
-    entrypoint: hydra serve -c /etc/config/hydra/hydra.yml --dev all
-    restart: unless-stopped
-    depends_on:
-      - hydra-migrate
-    networks:
-      - intranet
+  # hydra:
+  #   image: docker.io/oryd/hydra:latest-sqlite
+  #   ports:
+  #     - "4444:4444" # Public port
+  #     - "4445:4445" # Admin port
+  #   volumes:
+  #     - type: volume
+  #       source: hydra-sqlite
+  #       target: /var/lib/sqlite
+  #       read_only: false
+  #     - type: bind
+  #       source: ./docker/hydra
+  #       target: /etc/config/hydra
+  #   environment:
+  #     - DSN=postgresql://hydra:hydra@postgres/hydra?sslmode=disable
+  #     - CORS_DEBUG=1
+  #   command: serve -c /etc/config/hydra/hydra.yml all --dev
+  #   # entrypoint: hydra serve -c /etc/config/hydra/hydra.yml --dev all
+  #   restart: unless-stopped
+  #   depends_on:
+  #     - hydra-migrate
+  #   network_mode: "host"
   hydra-migrate:
-    image: hydra:latest
+    image: docker.io/oryd/hydra:latest-sqlite
+  #   image: hydra:latest
     environment:
-      - DSN=postgresql://hydra:hydra@postgres/hydra?sslmode=disable
-    command: exec hydra migrate -c /etc/config/hydra/hydra.yml sql -e --yes
+      - DSN=postgresql://hydra:hydra@localhost:5432/hydra?sslmode=disable
+    command: migrate -c /etc/config/hydra/hydra.yml sql -e --yes
+    # command: exec hydra migrate -c /etc/config/hydra/hydra.yml sql -e --yes
     volumes:
       - type: volume
         source: hydra-sqlite
@@ -78,24 +78,23 @@ services:
         source: ./docker/hydra
         target: /etc/config/hydra
     restart: on-failure
-    networks:
-      - intranet
+    network_mode: "host"
     depends_on:
       postgres:
         condition: service_healthy
   mailslurper:
     image: oryd/mailslurper:latest-smtps
-    ports:
-      - '4436:4436'
-      - '4437:4437'
+    # ports:
+    #   - '4436:4436'
+    #   - '4437:4437'
     networks:
       - intranet
   postgres:
     image: postgres
     container_name: postgres
     restart: always
-    ports:
-      - 5432:5432
+    # ports:
+    #   - 5432:5432
     environment:
       POSTGRES_DB: hydra
       POSTGRES_USER: hydra
@@ -105,8 +104,7 @@ services:
       interval: 5s
       timeout: 5s
       retries: 5
-    networks:
-      - intranet
+    network_mode: "host"
 networks:
   intranet:
 volumes:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -43,11 +43,10 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
   hydra:
-    image: oryd/hydra:v2.1.1
+    image: hydra:latest
     ports:
       - "4444:4444" # Public port
       - "4445:4445" # Admin port
-    command: serve -c /etc/config/hydra/hydra.yml all --dev
     volumes:
       - type: volume
         source: hydra-sqlite
@@ -57,18 +56,19 @@ services:
         source: ./docker/hydra
         target: /etc/config/hydra
     environment:
-      - DSN=sqlite:///var/lib/sqlite/db.sqlite?_fk=true
+      - DSN=postgresql://hydra:hydra@postgres/hydra?sslmode=disable
       - CORS_DEBUG=1
+    entrypoint: hydra serve -c /etc/config/hydra/hydra.yml --dev all
     restart: unless-stopped
     depends_on:
       - hydra-migrate
     networks:
       - intranet
   hydra-migrate:
-    image: oryd/hydra:v2.1.1
+    image: hydra:latest
     environment:
-      - DSN=sqlite:///var/lib/sqlite/db.sqlite?_fk=true
-    command: migrate -c /etc/config/hydra/hydra.yml sql -e --yes
+      - DSN=postgresql://hydra:hydra@postgres/hydra?sslmode=disable
+    command: exec hydra migrate -c /etc/config/hydra/hydra.yml sql -e --yes
     volumes:
       - type: volume
         source: hydra-sqlite
@@ -80,6 +80,9 @@ services:
     restart: on-failure
     networks:
       - intranet
+    depends_on:
+      postgres:
+        condition: service_healthy
   mailslurper:
     image: oryd/mailslurper:latest-smtps
     ports:
@@ -94,44 +97,16 @@ services:
     ports:
       - 5432:5432
     environment:
-      POSTGRES_DB: openfga
-      POSTGRES_USER: openfga
-      POSTGRES_PASSWORD: openfga
+      POSTGRES_DB: hydra
+      POSTGRES_USER: hydra
+      POSTGRES_PASSWORD: hydra
     healthcheck:
-      test: [ "CMD-SHELL", "pg_isready -U openfga" ]
+      test: [ "CMD-SHELL", "pg_isready -U hydra" ]
       interval: 5s
       timeout: 5s
       retries: 5
-  migrateopenfga:
-    image: openfga/openfga:latest
-    container_name: migrateopenfga
-    command: migrate --datastore-engine postgres --datastore-uri 'postgresql://openfga:openfga@postgres/openfga?sslmode=disable'
-    depends_on:
-      postgres:
-        condition: service_healthy
-  insert-hardcoded-store:
-    image: governmentpaas/psql
-    container_name: insert-hardcoded-store
-    command: psql -Atx postgresql://openfga:openfga@postgres/openfga?sslmode=disable -c "INSERT INTO store (id,name,created_at,updated_at) VALUES ('01GP1254CHWJC1MNGVB0WDG1T0','login-ui',NOW(),NOW());"
-    depends_on:
-      migrateopenfga:
-        condition: service_completed_successfully
-  openfga:
-    image: openfga/openfga:latest
-    environment:
-      OPENFGA_DATASTORE_ENGINE: "postgres"
-      OPENFGA_DATASTORE_URI: "postgresql://openfga:openfga@postgres/openfga?sslmode=disable"
-      OPENFGA_AUTHN_PRESHARED_KEYS: "42"
-    command: run
-    ports:
-      - 8080:8080
-      - 8081:8081
-      - 3000:3000
-    depends_on:
-      migrateopenfga:
-        condition: service_completed_successfully
-      insert-hardcoded-store:
-        condition: service_completed_successfully
+    networks:
+      - intranet
 networks:
   intranet:
 volumes:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,7 +1,7 @@
 version: '3.7'
 services:
   kratos-migrate:
-    image: oryd/kratos:v1.0.0
+    image: oryd/kratos:v1.1.0
     environment:
       - DSN=sqlite:///var/lib/sqlite/db.sqlite?_fk=true&mode=rwc
     volumes:
@@ -18,7 +18,7 @@ services:
   kratos:
     depends_on:
       - kratos-migrate
-    image: oryd/kratos:v1.0.0
+    image: oryd/kratos:v1.1.0
     # ports:
     #   - '4433:4433' # public
     #   - '4434:4434' # admin

--- a/docker/hydra/hydra.yml
+++ b/docker/hydra/hydra.yml
@@ -18,6 +18,9 @@ log:
 
 oauth2:
   expose_internal_errors: true
+  device_authorization:
+    # configure how often a non-interactive device should poll the device token endpoint, default 5s
+    token_polling_interval: 5s
 
 urls:
   self:
@@ -26,6 +29,8 @@ urls:
   consent: http://localhost:4455/ui/consent
   login: http://localhost:4455/ui/login
   error: http://localhost:4455/ui/oidc_error
+  device: http://localhost:4455/ui/device
+  post_device_done: http://localhost:4455/post_device
 
 secrets:
   system:

--- a/docker/hydra/hydra.yml
+++ b/docker/hydra/hydra.yml
@@ -20,17 +20,17 @@ oauth2:
   expose_internal_errors: true
   device_authorization:
     # configure how often a non-interactive device should poll the device token endpoint, default 5s
-    token_polling_interval: 5s
+    token_polling_interval: 1s
 
 urls:
   self:
-    issuer: http://hydra:4444
+    issuer: http://localhost:4444
     public: http://localhost:4444
   consent: http://localhost:4455/ui/consent
   login: http://localhost:4455/ui/login
   error: http://localhost:4455/ui/oidc_error
-  device: http://localhost:4455/ui/device
-  post_device_done: http://localhost:4455/post_device
+  device_verification: http://localhost:4455/ui/device
+  # post_device_done: http://localhost:4455/post_device
 
 secrets:
   system:

--- a/docker/kratos/kratos.yml
+++ b/docker/kratos/kratos.yml
@@ -1,7 +1,7 @@
 version: v1.0.0
 
 oauth2_provider:
-    url: "http://hydra:4445"
+    url: "http://localhost:4445"
 log:
     level: debug
     format: text

--- a/pkg/device/handlers.go
+++ b/pkg/device/handlers.go
@@ -1,0 +1,57 @@
+package device
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/canonical/identity-platform-login-ui/internal/logging"
+	"github.com/go-chi/chi/v5"
+)
+
+type API struct {
+	service ServiceInterface
+
+	logger logging.LoggerInterface
+}
+
+func (a *API) RegisterEndpoints(mux *chi.Mux) {
+	mux.Put("/api/device", a.handleDevice)
+}
+
+func (a *API) handleDevice(w http.ResponseWriter, r *http.Request) {
+	challenge := r.URL.Query().Get("device_challenge")
+
+	body, err := a.service.ParseUserCodeBody(r)
+	if err != nil {
+		a.logger.Errorf("Error when parsing request body: %v\n", err)
+		http.Error(w, "Failed to parse user code", http.StatusInternalServerError)
+		return
+	}
+
+	deviceResp, err := a.service.AcceptUserCode(challenge, body)
+	if err != nil {
+		// TODO: return different status code for when the code is wrong
+		a.logger.Errorf("Failed to accept user code: %v\n", err)
+		http.Error(w, "Failed to accept user code", http.StatusInternalServerError)
+		return
+	}
+	resp, err := json.Marshal(deviceResp)
+	if err != nil {
+		a.logger.Errorf("Error when marshalling Json: %v\n", err)
+		http.Error(w, "Failed to parse response", http.StatusInternalServerError)
+		return
+	}
+
+	w.Write(resp)
+	w.WriteHeader(http.StatusOK)
+}
+
+func NewAPI(service ServiceInterface, logger logging.LoggerInterface) *API {
+	a := new(API)
+
+	a.service = service
+
+	a.logger = logger
+
+	return a
+}

--- a/pkg/device/interfaces.go
+++ b/pkg/device/interfaces.go
@@ -1,0 +1,21 @@
+package device
+
+import (
+	"net/http"
+
+	hClient "github.com/ory/hydra-client-go/v2"
+	kClient "github.com/ory/kratos-client-go"
+)
+
+type KratosClientInterface interface {
+	FrontendApi() kClient.FrontendApi
+}
+
+type HydraClientInterface interface {
+	OAuth2Api() hClient.OAuth2Api
+}
+
+type ServiceInterface interface {
+	AcceptUserCode(string, *DeviceCodeRequest) (*DeviceCodeResponse, error)
+	ParseUserCodeBody(*http.Request) (*DeviceCodeRequest, error)
+}

--- a/pkg/device/service.go
+++ b/pkg/device/service.go
@@ -1,0 +1,96 @@
+package device
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/canonical/identity-platform-login-ui/internal/logging"
+	"github.com/canonical/identity-platform-login-ui/internal/monitoring"
+	"github.com/canonical/identity-platform-login-ui/internal/tracing"
+)
+
+type Service struct {
+	hydraAdminUrl string
+
+	tracer  tracing.TracingInterface
+	monitor monitoring.MonitorInterface
+	logger  logging.LoggerInterface
+}
+
+type DeviceCodeRequest struct {
+	Code string `json:"user_code,omitempty"`
+}
+
+type DeviceCodeResponse struct {
+	RedirectTo string `json:"redirect_to,omitempty"`
+}
+
+func (s *Service) AcceptUserCode(deviceChallenge string, code *DeviceCodeRequest) (*DeviceCodeResponse, error) {
+	body, err := json.Marshal(code)
+	if err != nil {
+		s.logger.Errorf("error when parsing request body: %s", err)
+		return nil, err
+	}
+
+	url := s.hydraAdminUrl + "/admin/oauth2/auth/requests/device/accept?challenge=" + deviceChallenge
+	req, _ := http.NewRequest(http.MethodPut, url, bytes.NewBuffer(body))
+	if err != nil {
+		s.logger.Errorf("error when constructing request: %s", err)
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		s.logger.Errorf("failed to verify device code: %s", err)
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		fmt.Println(err)
+	}
+	acceptDeviceResponse := new(DeviceCodeResponse)
+	err = json.Unmarshal(respBody, acceptDeviceResponse)
+	if err != nil {
+		s.logger.Errorf("error when parsing request body: %s", err)
+		return nil, err
+	}
+
+	return acceptDeviceResponse, nil
+}
+
+func (s *Service) ParseUserCodeBody(r *http.Request) (*DeviceCodeRequest, error) {
+	body := new(DeviceCodeRequest)
+
+	err := parseBody(r.Body, &body)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return body, nil
+}
+
+func parseBody(b io.ReadCloser, body interface{}) error {
+	decoder := json.NewDecoder(b)
+	err := decoder.Decode(body)
+	return err
+}
+
+func NewService(hydraAdminUrl string, tracer tracing.TracingInterface, monitor monitoring.MonitorInterface, logger logging.LoggerInterface) *Service {
+	s := new(Service)
+
+	s.hydraAdminUrl = hydraAdminUrl
+
+	s.monitor = monitor
+	s.tracer = tracer
+	s.logger = logger
+
+	return s
+}

--- a/pkg/web/router.go
+++ b/pkg/web/router.go
@@ -13,6 +13,7 @@ import (
 	chi "github.com/go-chi/chi/v5"
 	middleware "github.com/go-chi/chi/v5/middleware"
 
+	"github.com/canonical/identity-platform-login-ui/pkg/device"
 	"github.com/canonical/identity-platform-login-ui/pkg/extra"
 	"github.com/canonical/identity-platform-login-ui/pkg/kratos"
 	"github.com/canonical/identity-platform-login-ui/pkg/metrics"
@@ -20,7 +21,7 @@ import (
 	"github.com/canonical/identity-platform-login-ui/pkg/ui"
 )
 
-func NewRouter(kratosClient *ik.Client, hydraClient *ih.Client, authzClient authz.AuthorizerInterface, distFS fs.FS, baseURL string, tracer tracing.TracingInterface, monitor monitoring.MonitorInterface, logger logging.LoggerInterface) http.Handler {
+func NewRouter(kratosClient *ik.Client, hydraClient *ih.Client, authzClient authz.AuthorizerInterface, hydraAdminUrl string, distFS fs.FS, baseURL string, tracer tracing.TracingInterface, monitor monitoring.MonitorInterface, logger logging.LoggerInterface) http.Handler {
 	router := chi.NewMux()
 
 	middlewares := make(chi.Middlewares, 0)
@@ -41,6 +42,10 @@ func NewRouter(kratosClient *ik.Client, hydraClient *ih.Client, authzClient auth
 
 	router.Use(middlewares...)
 
+	device.NewAPI(
+		device.NewService(hydraAdminUrl, tracer, monitor, logger),
+		logger,
+	).RegisterEndpoints(router)
 	kratos.NewAPI(
 		kratos.NewService(kratosClient, hydraClient, authzClient, tracer, monitor, logger),
 		baseURL,

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -33,7 +33,7 @@
         "typescript": "5.3.3"
       },
       "engines": {
-        "node": "18"
+        "node": "20"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/ui/pages/device.tsx
+++ b/ui/pages/device.tsx
@@ -1,0 +1,73 @@
+import { Card, Row } from "@canonical/react-components";
+import axios from "axios";
+import Head from "next/head";
+import { useRouter } from "next/router";
+import React, { FormEvent, useCallback, useEffect } from "react";
+
+export interface Response {
+  data: {
+    redirect_to?: string;
+  };
+}
+
+function acceptUserCode(userCode: string, challenge: string) {
+  axios
+    .put("/api/device?device_challenge=" + String(challenge), {
+      user_code: userCode,
+    })
+    .then(({ data }: Response) => {
+      if (data.redirect_to) {
+        window.location.href = data.redirect_to;
+      }
+    })
+    .catch(() => {
+      return Promise.reject();
+    });
+  return;
+}
+
+export default function Page() {
+  const router = useRouter();
+  const { device_challenge: challenge, user_code: code } = router.query;
+
+  useEffect(() => {
+    // If the router is not ready yet, or we already have a flow, do nothing.
+    if (!router.isReady) {
+      return;
+    }
+    if (code != null) {
+      acceptUserCode(String(code), String(challenge));
+    }
+  }, [code]);
+
+  const handleSubmit = useCallback(
+    (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+
+      const formData = new FormData(event.currentTarget);
+      const userCode = formData.get("user_code");
+      acceptUserCode(String(userCode), String(challenge));
+    },
+    [challenge],
+  );
+
+  return (
+    <>
+      <Head>
+        <title>Enter code</title>
+      </Head>
+      <Row className="p-strip is-shallow">
+        <div className="login-card">
+          <div>
+            <Card title="Enter your code">
+              <form onSubmit={handleSubmit}>
+                <input type="text" name="user_code" />
+                <button type="submit">Submit</button>
+              </form>
+            </Card>
+          </div>
+        </div>
+      </Row>
+    </>
+  );
+}


### PR DESCRIPTION
POC for Hydra device flow.

To test:
- Bring up the rest of the components with: 
```console
docker-compose -f docker-compose.dev.yml up --build --force-recreate
```
- Register a client in Hydra that can:
```console
hydra create client \
  --endpoint http://127.0.0.1:4445 \
  --name noauth \
  --grant-type urn:ietf:params:oauth:grant-type:device_code \
  --scope openid,offline \
  --token-endpoint-auth-method none
```
- You can use the client found in https://github.com/canonical/hydra-rock/tree/IAM-597 (only config needed is `OAUTH_CLIENT_ID="<client_id>"`, where <client_id> is taken from the previous step)
- Run the login UI with the usual config

Note
- [ ]  I couldn't find a way to fetch info about the client so that we can ask for the user to authorize that specific device.