### PR TITLE
Fix container structure tests

### DIFF
--- a/structure-tests.yaml
+++ b/structure-tests.yaml
@@ -19,4 +19,4 @@ fileExistenceTests:
 commandTests:
   - name: "application version"
     command: "/usr/bin/identity-platform-login-ui"
-    args: ["-version"]
+    args: ["version"]


### PR DESCRIPTION
Fix container structure tests (bug was introduced by the refactor of the CLI)

Question:
Should we add tests for the rest of the commands?