### PR TITLE
Update device code page

### DIFF
--- a/docker/hydra/hydra.yml
+++ b/docker/hydra/hydra.yml
@@ -18,6 +18,9 @@ log:
 
 oauth2:
   expose_internal_errors: true
+  device_authorization:
+    # configure how often a non-interactive device should poll the device token endpoint, default 5s
+    token_polling_interval: 5s
 
 urls:
   self:
@@ -26,6 +29,8 @@ urls:
   consent: http://localhost:4455/ui/consent
   login: http://localhost:4455/ui/login
   error: http://localhost:4455/ui/oidc_error
+  device_verification: http://localhost:4455/ui/device_code
+  post_device_done: http://localhost:4455/post_device
 
 secrets:
   system:

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/ory/hydra-client-go/v2 v2.1.1
 	github.com/ory/kratos-client-go v0.13.1
 	github.com/prometheus/client_golang v1.17.0
+	github.com/spf13/cobra v1.8.0
 	github.com/stretchr/testify v1.8.4
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.45.0
 	go.opentelemetry.io/contrib/propagators/jaeger v1.20.0
@@ -41,7 +42,6 @@ require (
 	github.com/prometheus/client_model v0.4.1-0.20230718164431-9a2bf3000d16 // indirect
 	github.com/prometheus/common v0.44.0 // indirect
 	github.com/prometheus/procfs v0.11.1 // indirect
-	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	go.opentelemetry.io/otel/metric v1.21.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,6 @@ github.com/go-chi/chi/v5 v5.0.10/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNIT
 github.com/go-chi/cors v1.2.1 h1:xEC8UT3Rlp2QuWNEr4Fs/c2EAGVKBwy/1vHx3bppil4=
 github.com/go-chi/cors v1.2.1/go.mod h1:sSbTewc+6wYHBBCW7ytsFSn836hqM7JxpglAy2Vzc58=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
-github.com/go-logr/logr v1.2.4 h1:g01GSCwiDw2xSZfjJ2/T9M+S6pFdcNtFYsp+Y43HYDQ=
-github.com/go-logr/logr v1.2.4/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.3.0 h1:2y3SDp0ZXuc6/cjLSZ+Q3ir+QB9T/iG5yYRXqsagWSY=
 github.com/go-logr/logr v1.3.0/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
@@ -28,8 +26,8 @@ github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaS
 github.com/golang/protobuf v1.5.3 h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg=
 github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
-github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0 h1:YBftPWNWd4WwGqtY2yeZL2ef8rHAxPBD8KFhJpmcqms=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0/go.mod h1:YN5jB8ie0yfIUg6VvR9Kz84aCaG7AsGZnLjhHbUqwPg=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
@@ -73,8 +71,6 @@ go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.45.0 h1:x8Z78aZ
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.45.0/go.mod h1:62CPTSry9QZtOaSsE3tOzhx6LzDhHnXJ6xHeMNNiM6Q=
 go.opentelemetry.io/contrib/propagators/jaeger v1.20.0 h1:iVhNKkMIpzyZqxk8jkDU2n4DFTD+FbpGacvooxEvyyc=
 go.opentelemetry.io/contrib/propagators/jaeger v1.20.0/go.mod h1:cpSABr0cm/AH/HhbJjn+AudBVUMgZWdfN3Gb+ZqxSZc=
-go.opentelemetry.io/otel v1.19.0 h1:MuS/TNf4/j4IXsZuJegVzI1cwut7Qc00344rgH7p8bs=
-go.opentelemetry.io/otel v1.19.0/go.mod h1:i0QyjOq3UPoTzff0PJB2N66fb4S0+rSbSB15/oyH9fY=
 go.opentelemetry.io/otel v1.21.0 h1:hzLeKBZEL7Okw2mGzZ0cc4k/A7Fta0uoPgaJCr8fsFc=
 go.opentelemetry.io/otel v1.21.0/go.mod h1:QZzNPQPm1zLX4gZK4cMi+71eaorMSGT3A4znnUvNNEo=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.19.0 h1:Mne5On7VWdx7omSrSSZvM4Kw7cS7NQkOOmLcgscI51U=
@@ -85,16 +81,10 @@ go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.19.0 h1:IeMey
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.19.0/go.mod h1:oVdCUtjq9MK9BlS7TtucsQwUcXcymNiEDjgDD2jMtZU=
 go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.19.0 h1:Nw7Dv4lwvGrI68+wULbcq7su9K2cebeCUrDjVrUJHxM=
 go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.19.0/go.mod h1:1MsF6Y7gTqosgoZvHlzcaaM8DIMNZgJh87ykokoNH7Y=
-go.opentelemetry.io/otel/metric v1.19.0 h1:aTzpGtV0ar9wlV4Sna9sdJyII5jTVJEvKETPiOKwvpE=
-go.opentelemetry.io/otel/metric v1.19.0/go.mod h1:L5rUsV9kM1IxCj1MmSdS+JQAcVm319EUrDVLrt7jqt8=
 go.opentelemetry.io/otel/metric v1.21.0 h1:tlYWfeo+Bocx5kLEloTjbcDwBuELRrIFxwdQ36PlJu4=
 go.opentelemetry.io/otel/metric v1.21.0/go.mod h1:o1p3CA8nNHW8j5yuQLdc1eeqEaPfzug24uvsyIEJRWM=
-go.opentelemetry.io/otel/sdk v1.19.0 h1:6USY6zH+L8uMH8L3t1enZPR3WFEmSTADlqldyHtJi3o=
-go.opentelemetry.io/otel/sdk v1.19.0/go.mod h1:NedEbbS4w3C6zElbLdPJKOpJQOrGUJ+GfzpjUvI0v1A=
 go.opentelemetry.io/otel/sdk v1.21.0 h1:FTt8qirL1EysG6sTQRZ5TokkU8d0ugCj8htOgThZXQ8=
 go.opentelemetry.io/otel/sdk v1.21.0/go.mod h1:Nna6Yv7PWTdgJHVRD9hIYywQBRx7pbox6nwBnZIxl/E=
-go.opentelemetry.io/otel/trace v1.19.0 h1:DFVQmlVbfVeOuBRrwdtaehRrWiL1JoVs9CPIQ1Dzxpg=
-go.opentelemetry.io/otel/trace v1.19.0/go.mod h1:mfaSyvGyEJEI0nyV2I4qhNQnbBOUUmYZpYojqMnX2vo=
 go.opentelemetry.io/otel/trace v1.21.0 h1:WD9i5gzvoUPuXIXH24ZNBudiarZDKuekPqi/E8fpfLc=
 go.opentelemetry.io/otel/trace v1.21.0/go.mod h1:LGbsEB0f9LGjN+OZaQQ26sohbOmiMR+BaslueVtS/qQ=
 go.opentelemetry.io/proto/otlp v1.0.0 h1:T0TX0tmXU8a3CbNXzEKGeU5mIVOdf0oykP+u2lIVU/I=
@@ -117,8 +107,6 @@ golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.4.0 h1:zxkM55ReGkDlKSM+Fu41A+zmbZuaPVbGMzvvdUPznYQ=
 golang.org/x/sync v0.4.0/go.mod h1:FU7BRWz2tNW+3quACPkgCx/L+uEAv1htQ0V83Z9Rj+Y=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
-golang.org/x/sys v0.12.0 h1:CM0HF96J0hcLAwsHPJZjfdNzs0gftsLfgKt57wWHJ0o=
-golang.org/x/sys v0.12.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.14.0 h1:Vz7Qs629MkJkGyHxUlRHizWJRG2j8fbQKjELVSNhy7Q=
 golang.org/x/sys v0.14.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/internal/hydra/client.go
+++ b/internal/hydra/client.go
@@ -3,28 +3,29 @@ package hydra
 import (
 	"net/http"
 
-	client "github.com/ory/hydra-client-go/v2"
+	hClient "github.com/ory/hydra-client-go/v2"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 )
 
 type Client struct {
-	c *client.APIClient
+	c         *hClient.APIClient
+	deviceApi *DeviceApiService
 }
 
-func (c *Client) OAuth2Api() client.OAuth2Api {
-	return c.c.OAuth2Api
+func (c *Client) OAuth2Api() OAuth2Api {
+	return c.deviceApi
 }
 
-func (c *Client) MetadataApi() client.MetadataApi {
+func (c *Client) MetadataApi() hClient.MetadataApi {
 	return c.c.MetadataApi
 }
 
 func NewClient(url string, debug bool) *Client {
 	c := new(Client)
 
-	configuration := client.NewConfiguration()
+	configuration := hClient.NewConfiguration()
 	configuration.Debug = debug
-	configuration.Servers = []client.ServerConfiguration{
+	configuration.Servers = []hClient.ServerConfiguration{
 		{
 			URL: url,
 		},
@@ -32,7 +33,8 @@ func NewClient(url string, debug bool) *Client {
 
 	configuration.HTTPClient = &http.Client{Transport: otelhttp.NewTransport(http.DefaultTransport)}
 
-	c.c = client.NewAPIClient(configuration)
+	c.c = hClient.NewAPIClient(configuration)
+	c.deviceApi = newDeviceApiService(c.c)
 
 	return c
 }

--- a/internal/hydra/device.go
+++ b/internal/hydra/device.go
@@ -1,0 +1,237 @@
+package hydra
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	hClient "github.com/ory/hydra-client-go/v2"
+)
+
+// We implement the device API logic, because the upstream sdk does not support it.
+// Otherwise we would have to fork the sdk
+// TODO(nsklikas): Remove this once upstream hydra supports the device flow
+
+type DeviceApiService struct {
+	client *hClient.APIClient
+	hClient.OAuth2Api
+}
+
+type APIError struct {
+	body  []byte
+	error string
+}
+
+// Error returns non-empty string if there was an error.
+func (e APIError) Error() string {
+	return e.error
+}
+
+// Body returns the raw bytes of the response
+func (e APIError) Body() []byte {
+	return e.body
+}
+
+// Prevent trying to import "fmt"
+func reportError(format string, a ...interface{}) error {
+	return fmt.Errorf(format, a...)
+}
+
+// AcceptDeviceUserCodeRequest Contains information on an device verification
+type AcceptDeviceUserCodeRequest struct {
+	UserCode *string `json:"user_code,omitempty"`
+}
+
+// NewAcceptDeviceUserCodeRequest instantiates a new AcceptDeviceUserCodeRequest object
+// This constructor will assign default values to properties that have it defined,
+// and makes sure properties required by API are set, but the set of arguments
+// will change when the set of required properties is changed
+func NewAcceptDeviceUserCodeRequest() *AcceptDeviceUserCodeRequest {
+	this := AcceptDeviceUserCodeRequest{}
+	return &this
+}
+
+// NewAcceptDeviceUserCodeRequestWithDefaults instantiates a new AcceptDeviceUserCodeRequest object
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set
+func NewAcceptDeviceUserCodeRequestWithDefaults() *AcceptDeviceUserCodeRequest {
+	this := AcceptDeviceUserCodeRequest{}
+	return &this
+}
+
+// GetUserCode returns the UserCode field value if set, zero value otherwise.
+func (o *AcceptDeviceUserCodeRequest) GetUserCode() string {
+	if o == nil || o.UserCode == nil {
+		var ret string
+		return ret
+	}
+	return *o.UserCode
+}
+
+// GetUserCodeOk returns a tuple with the UserCode field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *AcceptDeviceUserCodeRequest) GetUserCodeOk() (*string, bool) {
+	if o == nil || o.UserCode == nil {
+		return nil, false
+	}
+	return o.UserCode, true
+}
+
+// HasUserCode returns a boolean if a field has been set.
+func (o *AcceptDeviceUserCodeRequest) HasUserCode() bool {
+	if o != nil && o.UserCode != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetUserCode gets a reference to the given string and assigns it to the UserCode field.
+func (o *AcceptDeviceUserCodeRequest) SetUserCode(v string) {
+	o.UserCode = &v
+}
+
+func (o AcceptDeviceUserCodeRequest) MarshalJSON() ([]byte, error) {
+	toSerialize := map[string]interface{}{}
+	if o.UserCode != nil {
+		toSerialize["user_code"] = o.UserCode
+	}
+	return json.Marshal(toSerialize)
+}
+
+type NullableAcceptDeviceUserCodeRequest struct {
+	value *AcceptDeviceUserCodeRequest
+	isSet bool
+}
+
+func (v NullableAcceptDeviceUserCodeRequest) Get() *AcceptDeviceUserCodeRequest {
+	return v.value
+}
+
+func (v *NullableAcceptDeviceUserCodeRequest) Set(val *AcceptDeviceUserCodeRequest) {
+	v.value = val
+	v.isSet = true
+}
+
+func (v NullableAcceptDeviceUserCodeRequest) IsSet() bool {
+	return v.isSet
+}
+
+func (v *NullableAcceptDeviceUserCodeRequest) Unset() {
+	v.value = nil
+	v.isSet = false
+}
+
+func NewNullableAcceptDeviceUserCodeRequest(val *AcceptDeviceUserCodeRequest) *NullableAcceptDeviceUserCodeRequest {
+	return &NullableAcceptDeviceUserCodeRequest{value: val, isSet: true}
+}
+
+func (v NullableAcceptDeviceUserCodeRequest) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.value)
+}
+
+func (v *NullableAcceptDeviceUserCodeRequest) UnmarshalJSON(src []byte) error {
+	v.isSet = true
+	return json.Unmarshal(src, &v.value)
+}
+
+type ApiAcceptUserCodeRequestRequest struct {
+	ctx                         context.Context
+	ApiService                  OAuth2Api
+	deviceChallenge             *string
+	acceptDeviceUserCodeRequest *AcceptDeviceUserCodeRequest
+}
+
+func (r ApiAcceptUserCodeRequestRequest) DeviceChallenge(deviceChallenge string) ApiAcceptUserCodeRequestRequest {
+	r.deviceChallenge = &deviceChallenge
+	return r
+}
+
+func (r ApiAcceptUserCodeRequestRequest) AcceptDeviceUserCodeRequest(acceptDeviceUserCodeRequest AcceptDeviceUserCodeRequest) ApiAcceptUserCodeRequestRequest {
+	r.acceptDeviceUserCodeRequest = &acceptDeviceUserCodeRequest
+	return r
+}
+
+func (r ApiAcceptUserCodeRequestRequest) Execute() (*hClient.OAuth2RedirectTo, *http.Response, error) {
+	return r.ApiService.AcceptUserCodeRequestExecute(r)
+}
+
+/*
+AcceptUserCodeRequest Accepts a device grant user_code request
+
+Accepts a device grant user_code request
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@return ApiAcceptUserCodeRequestRequest
+*/
+func (a *DeviceApiService) AcceptUserCodeRequest(ctx context.Context) ApiAcceptUserCodeRequestRequest {
+	return ApiAcceptUserCodeRequestRequest{
+		ApiService: a,
+		ctx:        ctx,
+	}
+}
+
+// Execute executes the request
+//
+//	@return OAuth2RedirectTo
+func (a *DeviceApiService) AcceptUserCodeRequestExecute(r ApiAcceptUserCodeRequestRequest) (*hClient.OAuth2RedirectTo, *http.Response, error) {
+	body, err := json.Marshal(r.acceptDeviceUserCodeRequest)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	localBasePath, err := a.client.GetConfig().ServerURLWithContext(r.ctx, "OAuth2ApiService.AcceptUserCodeRequest")
+	if err != nil {
+		return nil, nil, err
+	}
+	url := localBasePath + "/admin/oauth2/auth/requests/device/accept"
+
+	req, err := http.NewRequest(http.MethodPut, url, bytes.NewBuffer(body))
+	if err != nil {
+		return nil, nil, reportError("error when constructing request: %s", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	query := req.URL.Query()
+	query.Add("challenge", *r.deviceChallenge)
+	req.URL.RawQuery = query.Encode()
+
+	client := a.client.GetConfig().HTTPClient
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, nil, reportError("failed to verify device code: %s", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	if resp.StatusCode >= 300 {
+		newErr := &APIError{
+			body:  respBody,
+			error: resp.Status,
+		}
+		return nil, resp, newErr
+	}
+
+	acceptDeviceResponse := new(hClient.OAuth2RedirectTo)
+	err = json.Unmarshal(respBody, acceptDeviceResponse)
+	if err != nil {
+		return nil, resp, reportError("error when parsing request body: %s", err)
+	}
+
+	return acceptDeviceResponse, resp, nil
+}
+
+func newDeviceApiService(api *hClient.APIClient) *DeviceApiService {
+	a := new(DeviceApiService)
+	a.client = api
+	a.OAuth2Api = api.OAuth2Api
+	return a
+}

--- a/internal/hydra/interfaces.go
+++ b/internal/hydra/interfaces.go
@@ -1,0 +1,21 @@
+package hydra
+
+import (
+	"context"
+	"net/http"
+
+	hClient "github.com/ory/hydra-client-go/v2"
+)
+
+// We implement the device API logic, because the upstream sdk does not support it.
+// Otherwise we would have to fork the sdk.
+// TODO(nsklikas): Remove this once upstream hydra supports the device flow
+type DeviceApi interface {
+	AcceptUserCodeRequest(context.Context) ApiAcceptUserCodeRequestRequest
+	AcceptUserCodeRequestExecute(ApiAcceptUserCodeRequestRequest) (*hClient.OAuth2RedirectTo, *http.Response, error)
+}
+
+type OAuth2Api interface {
+	hClient.OAuth2Api
+	DeviceApi
+}

--- a/pkg/device/handlers.go
+++ b/pkg/device/handlers.go
@@ -1,0 +1,56 @@
+package device
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/canonical/identity-platform-login-ui/internal/logging"
+	"github.com/go-chi/chi/v5"
+)
+
+type API struct {
+	service ServiceInterface
+
+	logger logging.LoggerInterface
+}
+
+func (a *API) RegisterEndpoints(mux *chi.Mux) {
+	mux.Put("/api/device", a.handleDevice)
+}
+
+func (a *API) handleDevice(w http.ResponseWriter, r *http.Request) {
+	challenge := r.URL.Query().Get("device_challenge")
+
+	body, err := a.service.ParseUserCodeBody(r)
+	if err != nil {
+		a.logger.Errorf("Error when parsing request body: %v\n", err)
+		http.Error(w, "Failed to parse user code", http.StatusInternalServerError)
+		return
+	}
+
+	deviceResp, err := a.service.AcceptUserCode(r.Context(), challenge, body)
+	if err != nil {
+		a.logger.Errorf("Failed to accept user code: %v\n", err)
+		http.Error(w, "Failed to accept user code", http.StatusBadRequest)
+		return
+	}
+	resp, err := json.Marshal(deviceResp)
+	if err != nil {
+		a.logger.Errorf("Error when marshalling Json: %v\n", err)
+		http.Error(w, "Failed to parse response", http.StatusInternalServerError)
+		return
+	}
+
+	w.Write(resp)
+	w.WriteHeader(http.StatusOK)
+}
+
+func NewAPI(service ServiceInterface, logger logging.LoggerInterface) *API {
+	a := new(API)
+
+	a.service = service
+
+	a.logger = logger
+
+	return a
+}

--- a/pkg/device/handlers_test.go
+++ b/pkg/device/handlers_test.go
@@ -1,0 +1,221 @@
+package device
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/canonical/identity-platform-login-ui/internal/hydra"
+	"github.com/go-chi/chi/v5"
+	hClient "github.com/ory/hydra-client-go/v2"
+	"go.uber.org/mock/gomock"
+)
+
+//go:generate mockgen -build_flags=--mod=mod -package device -destination ./mock_logger.go -source=../../internal/logging/interfaces.go
+//go:generate mockgen -build_flags=--mod=mod -package device -destination ./mock_device.go -source=./interfaces.go
+
+func TestHandleDeviceUserCodeAcceptSuccess(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := NewMockLoggerInterface(ctrl)
+	mockService := NewMockServiceInterface(ctrl)
+
+	accept := hClient.NewOAuth2RedirectTo("test")
+
+	code := "ABCDEFGH"
+	challenge := "7bb518c4eec2454dbb289f5fdb4c0ee2"
+
+	userCodeRequest := hydra.NewAcceptDeviceUserCodeRequest()
+	userCodeRequest.UserCode = &code
+	jsonBody, _ := userCodeRequest.MarshalJSON()
+
+	req := httptest.NewRequest(http.MethodPut, "/api/device", io.NopCloser(bytes.NewBuffer(jsonBody)))
+	values := req.URL.Query()
+	values.Add("device_challenge", challenge)
+	req.URL.RawQuery = values.Encode()
+
+	mockService.EXPECT().ParseUserCodeBody(gomock.Any()).Return(userCodeRequest, nil)
+	mockService.EXPECT().AcceptUserCode(gomock.Any(), challenge, userCodeRequest).Return(accept, nil)
+
+	mux := chi.NewMux()
+	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	res := w.Result()
+
+	data, err := ioutil.ReadAll(res.Body)
+	defer res.Body.Close()
+
+	if err != nil {
+		t.Fatalf("expected error to be nil got %v", err)
+	}
+
+	redirect := hClient.NewOAuth2RedirectToWithDefaults()
+	if err := json.Unmarshal(data, redirect); err != nil {
+		t.Fatalf("expected error to be nil got %v", err)
+	}
+
+	if redirect.RedirectTo != accept.RedirectTo {
+		t.Fatalf("expected %s, got %s.", accept.RedirectTo, redirect.RedirectTo)
+	}
+}
+
+func TestHandleDeviceUserCodeAcceptParseUserCodeBodyFailure(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := NewMockLoggerInterface(ctrl)
+	mockService := NewMockServiceInterface(ctrl)
+
+	code := "ABCDEFGH"
+	challenge := "7bb518c4eec2454dbb289f5fdb4c0ee2"
+
+	userCodeRequest := hydra.NewAcceptDeviceUserCodeRequest()
+	userCodeRequest.UserCode = &code
+	jsonBody, _ := userCodeRequest.MarshalJSON()
+
+	req := httptest.NewRequest(http.MethodPut, "/api/device", io.NopCloser(bytes.NewBuffer(jsonBody)))
+	values := req.URL.Query()
+	values.Add("device_challenge", challenge)
+	req.URL.RawQuery = values.Encode()
+
+	mockService.EXPECT().ParseUserCodeBody(gomock.Any()).Return(nil, fmt.Errorf("error"))
+	mockLogger.EXPECT().Errorf(gomock.Any(), gomock.Any()).Times(1)
+
+	mux := chi.NewMux()
+	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	res := w.Result()
+
+	if res.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("expected HTTP status code 500 got %v", res.StatusCode)
+	}
+}
+
+func TestHandleDeviceUserCodeAcceptAcceptUserCodeFailure(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := NewMockLoggerInterface(ctrl)
+	mockService := NewMockServiceInterface(ctrl)
+
+	code := "ABCDEFGH"
+	challenge := "7bb518c4eec2454dbb289f5fdb4c0ee2"
+
+	userCodeRequest := hydra.NewAcceptDeviceUserCodeRequest()
+	userCodeRequest.UserCode = &code
+	jsonBody, _ := userCodeRequest.MarshalJSON()
+
+	req := httptest.NewRequest(http.MethodPut, "/api/device", io.NopCloser(bytes.NewBuffer(jsonBody)))
+	values := req.URL.Query()
+	values.Add("device_challenge", challenge)
+	req.URL.RawQuery = values.Encode()
+
+	mockService.EXPECT().ParseUserCodeBody(gomock.Any()).Return(userCodeRequest, nil)
+	mockService.EXPECT().AcceptUserCode(gomock.Any(), challenge, userCodeRequest).Return(nil, fmt.Errorf("error"))
+	mockLogger.EXPECT().Errorf(gomock.Any(), gomock.Any()).Times(1)
+
+	mux := chi.NewMux()
+	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	res := w.Result()
+
+	if res.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("expected HTTP status code 500 got %v", res.StatusCode)
+	}
+}
+
+func TestHandleDeviceUserCodeInvalidCode(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := NewMockLoggerInterface(ctrl)
+	mockService := NewMockServiceInterface(ctrl)
+
+	code := "ABCDEFGH"
+	challenge := "7bb518c4eec2454dbb289f5fdb4c0ee2"
+
+	userCodeRequest := hydra.NewAcceptDeviceUserCodeRequest()
+	userCodeRequest.UserCode = &code
+	jsonBody, _ := userCodeRequest.MarshalJSON()
+
+	req := httptest.NewRequest(http.MethodPut, "/api/device", io.NopCloser(bytes.NewBuffer(jsonBody)))
+	values := req.URL.Query()
+	values.Add("device_challenge", challenge)
+	req.URL.RawQuery = values.Encode()
+
+	err := fmt.Errorf("404 Not Found")
+	expectedErrorBody := NOT_FOUND_ERROR_DESC + "\n"
+
+	mockService.EXPECT().ParseUserCodeBody(gomock.Any()).Return(userCodeRequest, nil)
+	mockService.EXPECT().AcceptUserCode(gomock.Any(), challenge, userCodeRequest).Return(nil, err)
+	mockLogger.EXPECT().Errorf(gomock.Any(), gomock.Any()).Times(1)
+
+	mux := chi.NewMux()
+	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	res := w.Result()
+
+	if res.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected HTTP status code 400 got %v", res.StatusCode)
+	}
+
+	data, err := ioutil.ReadAll(res.Body)
+	defer res.Body.Close()
+
+	if err != nil {
+		t.Fatalf("expected error to be nil got %v", err)
+	}
+	errorBody := string(data)
+	if errorBody != expectedErrorBody {
+		t.Fatalf("expected '%v' got '%v'", expectedErrorBody, string(data))
+	}
+}
+
+func TestHandleDeviceUserCodeUnexpectedError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := NewMockLoggerInterface(ctrl)
+	mockService := NewMockServiceInterface(ctrl)
+
+	code := "ABCDEFGH"
+	challenge := "7bb518c4eec2454dbb289f5fdb4c0ee2"
+
+	userCodeRequest := hydra.NewAcceptDeviceUserCodeRequest()
+	userCodeRequest.UserCode = &code
+	jsonBody, _ := userCodeRequest.MarshalJSON()
+
+	req := httptest.NewRequest(http.MethodPut, "/api/device", io.NopCloser(bytes.NewBuffer(jsonBody)))
+	values := req.URL.Query()
+	values.Add("device_challenge", challenge)
+	req.URL.RawQuery = values.Encode()
+
+	mockService.EXPECT().ParseUserCodeBody(gomock.Any()).Return(userCodeRequest, nil)
+	mockService.EXPECT().AcceptUserCode(gomock.Any(), challenge, userCodeRequest).Return(nil, fmt.Errorf("error"))
+	mockLogger.EXPECT().Errorf(gomock.Any(), gomock.Any()).Times(1)
+
+	mux := chi.NewMux()
+	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	res := w.Result()
+
+	if res.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("expected HTTP status code 400 got %v", res.StatusCode)
+	}
+}

--- a/pkg/device/interfaces.go
+++ b/pkg/device/interfaces.go
@@ -1,0 +1,24 @@
+package device
+
+import (
+	"context"
+	"net/http"
+
+	hClient "github.com/ory/hydra-client-go/v2"
+	kClient "github.com/ory/kratos-client-go"
+
+	"github.com/canonical/identity-platform-login-ui/internal/hydra"
+)
+
+type KratosClientInterface interface {
+	FrontendApi() kClient.FrontendApi
+}
+
+type HydraClientInterface interface {
+	OAuth2Api() hydra.OAuth2Api
+}
+
+type ServiceInterface interface {
+	AcceptUserCode(context.Context, string, *hydra.AcceptDeviceUserCodeRequest) (*hClient.OAuth2RedirectTo, error)
+	ParseUserCodeBody(*http.Request) (*hydra.AcceptDeviceUserCodeRequest, error)
+}

--- a/pkg/device/service.go
+++ b/pkg/device/service.go
@@ -1,0 +1,70 @@
+package device
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+
+	hClient "github.com/ory/hydra-client-go/v2"
+
+	"github.com/canonical/identity-platform-login-ui/internal/hydra"
+	"github.com/canonical/identity-platform-login-ui/internal/logging"
+	"github.com/canonical/identity-platform-login-ui/internal/monitoring"
+	"github.com/canonical/identity-platform-login-ui/internal/tracing"
+)
+
+type Service struct {
+	hydra HydraClientInterface
+
+	tracer  tracing.TracingInterface
+	monitor monitoring.MonitorInterface
+	logger  logging.LoggerInterface
+}
+
+func (s *Service) AcceptUserCode(ctx context.Context, deviceChallenge string, req *hydra.AcceptDeviceUserCodeRequest) (*hClient.OAuth2RedirectTo, error) {
+	ctx, span := s.tracer.Start(ctx, "device.service.AcceptUserCode")
+	defer span.End()
+
+	accept, res, err := s.hydra.OAuth2Api().AcceptUserCodeRequest(ctx).
+		DeviceChallenge(deviceChallenge).
+		AcceptDeviceUserCodeRequest(*req).
+		Execute()
+
+	if err != nil {
+		s.logger.Debugf("full HTTP response: %v", res)
+		return nil, err
+	}
+
+	return accept, nil
+}
+
+func (s *Service) ParseUserCodeBody(r *http.Request) (*hydra.AcceptDeviceUserCodeRequest, error) {
+	body := new(hydra.AcceptDeviceUserCodeRequest)
+
+	err := parseBody(r.Body, &body)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return body, nil
+}
+
+func parseBody(b io.ReadCloser, body interface{}) error {
+	decoder := json.NewDecoder(b)
+	err := decoder.Decode(body)
+	return err
+}
+
+func NewService(hydra HydraClientInterface, tracer tracing.TracingInterface, monitor monitoring.MonitorInterface, logger logging.LoggerInterface) *Service {
+	s := new(Service)
+
+	s.hydra = hydra
+
+	s.monitor = monitor
+	s.tracer = tracer
+	s.logger = logger
+
+	return s
+}

--- a/pkg/device/service_test.go
+++ b/pkg/device/service_test.go
@@ -1,0 +1,157 @@
+package device
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	reflect "reflect"
+	"testing"
+
+	"github.com/canonical/identity-platform-login-ui/internal/hydra"
+	"github.com/canonical/identity-platform-login-ui/internal/monitoring"
+	hClient "github.com/ory/hydra-client-go/v2"
+	trace "go.opentelemetry.io/otel/trace"
+	"go.uber.org/mock/gomock"
+)
+
+//go:generate mockgen -build_flags=--mod=mod -package device -destination ./mock_logger.go -source=../../internal/logging/interfaces.go
+//go:generate mockgen -build_flags=--mod=mod -package device -destination ./mock_device.go -source=./interfaces.go
+//go:generate mockgen -build_flags=--mod=mod -package device -destination ./mock_monitor.go -source=../../internal/monitoring/interfaces.go
+//go:generate mockgen -build_flags=--mod=mod -package device -destination ./mock_tracing.go -source=../../internal/tracing/interfaces.go
+//go:generate mockgen -build_flags=--mod=mod -package device -destination ./mock_hydra.go -source=../../internal/hydra/interfaces.go
+
+func TestParseUserCodeBodySuccess(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := NewMockLoggerInterface(ctrl)
+	mockHydra := NewMockHydraClientInterface(ctrl)
+	mockTracer := NewMockTracingInterface(ctrl)
+	mockMonitor := monitoring.NewMockMonitorInterface(ctrl)
+
+	code := "ABCDEFGH"
+
+	userCodeRequest := hydra.NewAcceptDeviceUserCodeRequest()
+	userCodeRequest.UserCode = &code
+	jsonBody, _ := userCodeRequest.MarshalJSON()
+
+	req := httptest.NewRequest(http.MethodPost, "http://some/path", io.NopCloser(bytes.NewBuffer(jsonBody)))
+
+	b, err := NewService(mockHydra, mockTracer, mockMonitor, mockLogger).ParseUserCodeBody(req)
+
+	actual, _ := b.MarshalJSON()
+	if !reflect.DeepEqual(actual, jsonBody) {
+		t.Fatalf("expected flow to be %v not %v", jsonBody, actual)
+	}
+	if err != nil {
+		t.Fatalf("expected error to be nil not  %v", err)
+	}
+}
+
+func TestParseUserCodeBodyFailure(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := NewMockLoggerInterface(ctrl)
+	mockHydra := NewMockHydraClientInterface(ctrl)
+	mockTracer := NewMockTracingInterface(ctrl)
+	mockMonitor := monitoring.NewMockMonitorInterface(ctrl)
+
+	body := []byte("aaaaa")
+
+	req := httptest.NewRequest(http.MethodPost, "http://some/path", io.NopCloser(bytes.NewBuffer(body)))
+
+	_, err := NewService(mockHydra, mockTracer, mockMonitor, mockLogger).ParseUserCodeBody(req)
+
+	if err == nil {
+		t.Fatal("expected error to be not nil")
+	}
+}
+
+func TestAcceptUserCodeSuccess(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := NewMockLoggerInterface(ctrl)
+	mockHydra := NewMockHydraClientInterface(ctrl)
+	mockTracer := NewMockTracingInterface(ctrl)
+	mockMonitor := monitoring.NewMockMonitorInterface(ctrl)
+	mockAuth2Api := NewMockOAuth2Api(ctrl)
+
+	ctx := context.Background()
+
+	code := "ABCDEFGH"
+	challenge := "7bb518c4eec2454dbb289f5fdb4c0ee2"
+
+	userCodeRequest := hydra.NewAcceptDeviceUserCodeRequest()
+	userCodeRequest.UserCode = &code
+	redirectTo := hClient.NewOAuth2RedirectTo("test")
+
+	req := hydra.ApiAcceptUserCodeRequestRequest{
+		ApiService: mockAuth2Api,
+	}
+	resp := http.Response{}
+
+	mockTracer.EXPECT().Start(ctx, "device.service.AcceptUserCode").Times(1).Return(ctx, trace.SpanFromContext(ctx))
+	mockHydra.EXPECT().OAuth2Api().Times(1).Return(mockAuth2Api)
+	mockAuth2Api.EXPECT().AcceptUserCodeRequest(ctx).Times(1).Return(req)
+	mockAuth2Api.EXPECT().AcceptUserCodeRequestExecute(gomock.Any()).Times(1).DoAndReturn(
+		func(r hydra.ApiAcceptUserCodeRequestRequest) (*hClient.OAuth2RedirectTo, *http.Response, error) {
+			if _challenge := (*string)(reflect.ValueOf(r).FieldByName("deviceChallenge").UnsafePointer()); *_challenge != challenge {
+				t.Fatalf("expected challenge to be %s, got %s", challenge, *_challenge)
+			}
+
+			return redirectTo, &resp, nil
+		},
+	)
+
+	rt, err := NewService(mockHydra, mockTracer, mockMonitor, mockLogger).AcceptUserCode(ctx, challenge, userCodeRequest)
+
+	if rt != redirectTo {
+		t.Fatalf("expected redirect to be %v not  %v", redirectTo, rt)
+	}
+	if err != nil {
+		t.Fatalf("expected error to be nil not  %v", err)
+	}
+}
+
+func TestAcceptUserCodeFailure(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := NewMockLoggerInterface(ctrl)
+	mockHydra := NewMockHydraClientInterface(ctrl)
+	mockTracer := NewMockTracingInterface(ctrl)
+	mockMonitor := monitoring.NewMockMonitorInterface(ctrl)
+	mockAuth2Api := NewMockOAuth2Api(ctrl)
+
+	ctx := context.Background()
+
+	code := "ABCDEFGH"
+	challenge := "7bb518c4eec2454dbb289f5fdb4c0ee2"
+
+	userCodeRequest := hydra.NewAcceptDeviceUserCodeRequest()
+	userCodeRequest.UserCode = &code
+
+	req := hydra.ApiAcceptUserCodeRequestRequest{
+		ApiService: mockAuth2Api,
+	}
+
+	mockLogger.EXPECT().Debugf(gomock.Any(), gomock.Any()).Times(1)
+	mockTracer.EXPECT().Start(ctx, "device.service.AcceptUserCode").Times(1).Return(ctx, trace.SpanFromContext(ctx))
+	mockHydra.EXPECT().OAuth2Api().Times(1).Return(mockAuth2Api)
+	mockAuth2Api.EXPECT().AcceptUserCodeRequest(ctx).Times(1).Return(req)
+	mockAuth2Api.EXPECT().AcceptUserCodeRequestExecute(gomock.Any()).Times(1).Return(nil, nil, fmt.Errorf("error"))
+
+	rt, err := NewService(mockHydra, mockTracer, mockMonitor, mockLogger).AcceptUserCode(ctx, challenge, userCodeRequest)
+
+	if rt != nil {
+		t.Fatalf("expected redirect to be nil not  %v", rt)
+	}
+	if err == nil {
+		t.Fatalf("expected error to be not nil")
+	}
+}

--- a/pkg/extra/interfaces.go
+++ b/pkg/extra/interfaces.go
@@ -6,6 +6,8 @@ import (
 
 	hClient "github.com/ory/hydra-client-go/v2"
 	kClient "github.com/ory/kratos-client-go"
+
+	"github.com/canonical/identity-platform-login-ui/internal/hydra"
 )
 
 type KratosClientInterface interface {
@@ -13,7 +15,7 @@ type KratosClientInterface interface {
 }
 
 type HydraClientInterface interface {
-	OAuth2Api() hClient.OAuth2Api
+	OAuth2Api() hydra.OAuth2Api
 }
 
 type ServiceInterface interface {

--- a/pkg/extra/service_test.go
+++ b/pkg/extra/service_test.go
@@ -19,7 +19,7 @@ import (
 //go:generate mockgen -build_flags=--mod=mod -package extra -destination ./mock_monitor.go -source=../../internal/monitoring/interfaces.go
 //go:generate mockgen -build_flags=--mod=mod -package extra -destination ./mock_tracing.go -source=../../internal/tracing/interfaces.go
 //go:generate mockgen -build_flags=--mod=mod -package extra -destination ./mock_kratos.go github.com/ory/kratos-client-go FrontendApi
-//go:generate mockgen -build_flags=--mod=mod -package extra -destination ./mock_hydra.go github.com/ory/hydra-client-go/v2 OAuth2Api
+//go:generate mockgen -build_flags=--mod=mod -package extra -destination ./mock_hydra.go -source=../../internal/hydra/interfaces.go
 
 func TestCheckSessionSuccess(t *testing.T) {
 	ctrl := gomock.NewController(t)

--- a/pkg/kratos/interfaces.go
+++ b/pkg/kratos/interfaces.go
@@ -6,6 +6,8 @@ import (
 
 	hClient "github.com/ory/hydra-client-go/v2"
 	kClient "github.com/ory/kratos-client-go"
+
+	"github.com/canonical/identity-platform-login-ui/internal/hydra"
 )
 
 type KratosClientInterface interface {
@@ -13,7 +15,7 @@ type KratosClientInterface interface {
 }
 
 type HydraClientInterface interface {
-	OAuth2Api() hClient.OAuth2Api
+	OAuth2Api() hydra.OAuth2Api
 }
 
 type AuthorizerInterface interface {

--- a/pkg/kratos/service_test.go
+++ b/pkg/kratos/service_test.go
@@ -23,7 +23,7 @@ import (
 //go:generate mockgen -build_flags=--mod=mod -package kratos -destination ./mock_monitor.go -source=../../internal/monitoring/interfaces.go
 //go:generate mockgen -build_flags=--mod=mod -package kratos -destination ./mock_tracing.go -source=../../internal/tracing/interfaces.go
 //go:generate mockgen -build_flags=--mod=mod -package kratos -destination ./mock_kratos.go github.com/ory/kratos-client-go FrontendApi
-//go:generate mockgen -build_flags=--mod=mod -package kratos -destination ./mock_hydra.go github.com/ory/hydra-client-go/v2 OAuth2Api
+//go:generate mockgen -build_flags=--mod=mod -package kratos -destination ./mock_hydra.go -source=../../internal/hydra/interfaces.go
 
 func TestCheckSessionSuccess(t *testing.T) {
 	ctrl := gomock.NewController(t)

--- a/pkg/web/router.go
+++ b/pkg/web/router.go
@@ -13,6 +13,7 @@ import (
 	chi "github.com/go-chi/chi/v5"
 	middleware "github.com/go-chi/chi/v5/middleware"
 
+	"github.com/canonical/identity-platform-login-ui/pkg/device"
 	"github.com/canonical/identity-platform-login-ui/pkg/extra"
 	"github.com/canonical/identity-platform-login-ui/pkg/kratos"
 	"github.com/canonical/identity-platform-login-ui/pkg/metrics"
@@ -41,6 +42,10 @@ func NewRouter(kratosClient *ik.Client, hydraClient *ih.Client, authzClient auth
 
 	router.Use(middlewares...)
 
+	device.NewAPI(
+		device.NewService(hydraClient, tracer, monitor, logger),
+		logger,
+	).RegisterEndpoints(router)
 	kratos.NewAPI(
 		kratos.NewService(kratosClient, hydraClient, authzClient, tracer, monitor, logger),
 		baseURL,

--- a/ui/pages/device_code.tsx
+++ b/ui/pages/device_code.tsx
@@ -1,25 +1,73 @@
 import type { NextPage } from "next";
-import React from "react";
+import axios from "axios";
+import { useRouter } from "next/router";
+import React, { FormEvent, useCallback, useEffect } from "react";
 import PageLayout from "../components/PageLayout";
-import { Button, Input } from "@canonical/react-components";
+import { Button, Form, Input } from "@canonical/react-components";
+
+export interface Response {
+  data: {
+    redirect_to?: string;
+  };
+}
+
+function acceptUserCode(userCode: string, challenge: string) {
+  axios
+    .put("/api/device?device_challenge=" + String(challenge), {
+      user_code: userCode,
+    })
+    .then(({ data }: Response) => {
+      if (data.redirect_to) {
+        window.location.href = data.redirect_to;
+      }
+    })
+    .catch(() => {
+      return Promise.reject();
+    });
+  return;
+}
 
 const DeviceCode: NextPage = () => {
+  const router = useRouter();
+  const { device_challenge: challenge, user_code: code } = router.query;
+
+  useEffect(() => {
+    // If the router is not ready yet, or we already have a flow, do nothing.
+    if (!router.isReady) {
+      return;
+    }
+  }, [code]);
+
+  const handleSubmit = useCallback(
+    (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+
+      const formData = new FormData(event.currentTarget);
+      const userCode = formData.get("code");
+      acceptUserCode(String(userCode), String(challenge));
+    },
+    [challenge],
+  );
+
   return (
     <PageLayout title="Enter code to continue">
-      <Input
-        id="code"
-        name="code"
-        type="text"
-        label="Terminal code"
-        placeholder="xxxx-xxxx"
-      />
-      <Button
-        type="submit"
-        appearance="positive"
-        className="u-no-margin--bottom"
-      >
-        Next
-      </Button>
+      <Form onSubmit={handleSubmit}>
+        <Input
+          id="code"
+          name="code"
+          type="text"
+          placeholder="XXXXXXXX"
+          autoFocus={true}
+          defaultValue={code}
+        />
+        <Button
+          type="submit"
+          appearance="positive"
+          className="u-no-margin--bottom"
+        >
+          Next
+        </Button>
+      </Form>
     </PageLayout>
   );
 };


### PR DESCRIPTION
IAM-736:
- Update the device code page.
![image](https://github.com/canonical/identity-platform-login-ui/assets/19745916/b0df5658-8dc9-4bb5-b3ad-ef0a7d918b79)

There are a couple problems with this PR:
- We do not use the Hydra sdk to call the Hydra API. If we wish to use the client sdk do we have to fork https://github.com/ory/hydra-client-go?
- It does not handle errors from the backend. If the user inputs a wrong code, then nothing happens
- From a UX perspective it would be better if we had one box per letter rather than a single box for the whole code, e.g. see netflix:
![image](https://github.com/canonical/identity-platform-login-ui/assets/19745916/de22a950-07ee-4c8f-a0fe-06a154894201)
