### PR TITLE
Add success screen for device flow WD-10251

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -33,7 +33,7 @@
         "typescript": "5.3.3"
       },
       "engines": {
-        "node": "18"
+        "node": "20"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/ui/pages/device_complete.tsx
+++ b/ui/pages/device_complete.tsx
@@ -1,0 +1,15 @@
+import type { NextPage } from "next";
+import React from "react";
+import PageLayout from "../components/PageLayout";
+
+const DeviceComplete: NextPage = () => {
+  return (
+    <PageLayout title="Sign in successful">
+      <p>
+        Your device has been successfully connected. You can close this tab.
+      </p>
+    </PageLayout>
+  );
+};
+
+export default DeviceComplete;


### PR DESCRIPTION
# Done

Added success screen for device flow under the url http://localhost:4455/ui/device_complete

Fixes: WD-10251

# Screenshot

![image](https://github.com/canonical/identity-platform-login-ui/assets/1155472/1a2b53cc-6ebe-4a68-b163-4e12fd41ec70)
