### PR TITLE
Add client_id to access token's aud

### DIFF
--- a/docker/hydra/hydra.yml
+++ b/docker/hydra/hydra.yml
@@ -22,6 +22,12 @@ oauth2:
     # configure how often a non-interactive device should poll the device token endpoint, default 5s
     token_polling_interval: 5s
 
+strategies:
+  access_token: jwt
+  jwt:
+    scope_claim: list
+  scope: exact
+
 urls:
   self:
     issuer: http://hydra:4444

--- a/internal/misc/http/helpers.go
+++ b/internal/misc/http/helpers.go
@@ -30,14 +30,11 @@ func GetUserClaims(i kratos_client.Identity, cr hydra_client.OAuth2ConsentReques
 		// We should never end up here
 		log.Printf("Unexpected traits format: %v\n", ok)
 	}
-	log.Println(traits)
 	for _, s := range cr.RequestedScope {
 		cs, ok := oidc.OIDCScopeMapping[s]
 		if !ok {
 			continue
 		}
-		log.Println(cs)
-		log.Println(s)
 		for _, c := range cs {
 			val, ok := traits[c]
 			if ok {

--- a/pkg/extra/service.go
+++ b/pkg/extra/service.go
@@ -63,9 +63,17 @@ func (s *Service) AcceptConsent(ctx context.Context, identity kClient.Identity, 
 	session := hClient.NewAcceptOAuth2ConsentRequestSession()
 	session.SetIdToken(misc.GetUserClaims(identity, *consent))
 
+	atAudience := make([]string, 0)
+	if consent.RequestedAccessTokenAudience != nil {
+		atAudience = append(atAudience, consent.RequestedAccessTokenAudience...)
+	}
+	if consent.HasClient() {
+		atAudience = append(atAudience, *consent.Client.ClientId)
+	}
+
 	r := hClient.NewAcceptOAuth2ConsentRequest()
 	r.SetGrantScope(consent.RequestedScope)
-	r.SetGrantAccessTokenAudience(consent.RequestedAccessTokenAudience)
+	r.SetGrantAccessTokenAudience(atAudience)
 	r.SetSession(*session)
 
 	ctx, span := s.tracer.Start(ctx, "hydra.OAuth2Api.AcceptOAuth2ConsentRequest")


### PR DESCRIPTION
IAM-909

Add client_id to access token's audience.
Before the change, a jwt access token would be
```
eyJhbGciOiJSUzI1NiIsImtpZCI6ImIwN2JkYTU2LTMyMmYtNGQ0Yi1hOTFiLWRmZjFlZjhiNjMyNyIsInR5cCI6IkpXVCJ9.eyJhdWQiOltdLCJjbGllbnRfaWQiOiI0NmQ3MjExNC0zYmRmLTQ0ZTItYjEzZC04NmMyY2NjOWUzNzUiLCJleHAiOjE3MTk5MzAyMDAsImV4dCI6e30sImlhdCI6MTcxOTkyNjU5OSwiaXNzIjoiaHR0cDovL2h5ZHJhOjQ0NDQiLCJqdGkiOiI3NmQyYzM4ZC01YjVkLTQ1OTgtOTEwZS0zNjNjYmExYjZkNWUiLCJuYmYiOjE3MTk5MjY1OTksInNjcCI6WyJvcGVuaWQiLCJwcm9maWxlIiwiZW1haWwiLCJvZmZsaW5lX2FjY2VzcyJdLCJzdWIiOiJjNDZmMzc0Ny0yY2QxLTRjMzgtODE3OS01MTcwYmQ2NjJmOGUifQ.NfUjWsgYsaOIILWeY9jrZDPfXBl6AuMf4vf52f1nJzUc4pixPVjxSG1_GSnZYQcksNtEic5q3Is0cjU1HCpipRsdpp0bRk4I4FZGOCbF6R-ZCSk1DvBhnLCROHGpC0761sPSxshOQo3GsouiNetDXmhZy1t3RQSywm3teM1GdFhyQUCwPIx-txnOOHbMU8mHRuHvpCaaH9KmwdA3-jRIEtadpU_sxyREzLoM8gGXnpFmR5nE8GICT44B_RLX7SCnmyxtRcEOIGnmZCGWyyc6xtl-gWFwAYb8aalVdgcFKgMY6vZwIR0uMWPT7UsE7j_yWIM9nih1DIgHtDw7yAdNG8dQWRyzEGflKpGeIOUjpiYxXmoogp0ivsrnNqdJyS01wy6w1L-IgiQCu-YhohhbplRZiOOft2xM3rd6poR_xRH1SNE-gnPP19wt7bvEMhedpaIbf_8Mj1PxF_ERWCG32FUEQSb2OYzLiXlWCBtbbBl8CvZncIZjT3-STuR8X7Lo5iRYQ61WCzguf1CwPPalxXoi4qbPMZNvyn4IdyMQR5-F96uof2wER7ktN6p-sKRIVZqH7T7wRsqSYCU8wi_0MBc1WRFkZmITi7dSjk4xLCDfBVg463ljvFSEX7Jbac2Uc4eoknwH9e0YRbSE_UQjGV2n6CWo6Yaltb-LGu-Rpv8
```
The userinfo response:
![image](https://github.com/canonical/identity-platform-login-ui/assets/19745916/86273888-0b3c-42c0-b6da-dbda37e55e8a)

After the change, the access tokens are like:
```
eyJhbGciOiJSUzI1NiIsImtpZCI6ImIwN2JkYTU2LTMyMmYtNGQ0Yi1hOTFiLWRmZjFlZjhiNjMyNyIsInR5cCI6IkpXVCJ9.eyJhdWQiOlsiMGM1NTU1ZTQtMjcyNy00MGM2LTg4MDMtODg0NDBmMWVmMTZiIl0sImNsaWVudF9pZCI6IjBjNTU1NWU0LTI3MjctNDBjNi04ODAzLTg4NDQwZjFlZjE2YiIsImV4cCI6MTcxOTkzMDMyNywiZXh0Ijp7fSwiaWF0IjoxNzE5OTI2NzI2LCJpc3MiOiJodHRwOi8vaHlkcmE6NDQ0NCIsImp0aSI6ImFmYmE0MmM0LTcxNzEtNDdiOC1hMmZjLWVjYjAxNWQzMTI0NyIsIm5iZiI6MTcxOTkyNjcyNiwic2NwIjpbIm9wZW5pZCIsInByb2ZpbGUiLCJlbWFpbCIsIm9mZmxpbmVfYWNjZXNzIl0sInN1YiI6ImM0NmYzNzQ3LTJjZDEtNGMzOC04MTc5LTUxNzBiZDY2MmY4ZSJ9.nuH7gny98TfSKDIcNAg-I8H-sovqagj8nZPazsfTLZvfNQP39XxxzZgdN_3UM4270TYggLI2zFOJx-2gSjIhRzwSSbzQy2jRyd0aLGuX5ElrsAkIwjBq_nakyOGVUOK7hwW_dnuaPkZRcX2qNwmlK5GRXuHc4TBJ0KapK8zhJ9rGUwUQ3v9v7F29uAxdA_Zs2d51NxIEB93GOSvFV3B-F450QDi9cBuiOIMyudyp_VrcJ_WbbCuCIbhBV-Hqz20lum4HVtwcNsZQseOsg8mXTSWx0HzYS_Uj7EXyM-262-DQO9iOmckebLLz0AHcRYMC-H0iQyPPE57FgmhCSDW-c9959zdcOxCjh6V43KBT8Tgmh5dnLXRvUdXuOb5Z4YYM2N-U0XK_MJo4zRfcjgBR6JyAaIvaM65Fy0TCkiYXdQr6gS7dq_VhRUTVz4xHPCJQ8U8iczpuw4ex1_Asy9FnqN1Fx78Jf7mH-1JXqZCOWL-NP5rhPlxccPoUVNInWqlcYrawimLCMtRMDKtDQ9-xXfB8Q17pTVx_akHiFMJ3GTp96cZCbvJvSCKrKha3fWReb6hEGJoN0T2QbgfxHgwdhoDiGkYmX05NOglFfD4Fg0t6ejeI-dTmqz1roAP5AjiGBs4DbwuqC2fGO2KCo65NrbTJjUvKAfVHEBu7eertyvU
```
The userinfo resp:
![image](https://github.com/canonical/identity-platform-login-ui/assets/19745916/b1e4d8e9-65a4-4928-b2a0-7f9d6a1f9772)


As you can see the `client_id` is automatically added to the AT `aud` and the userinfo remains the same. I thought about adding the `client_id` to the userinfo as well, but that would go against the purpose of the endpoint (the client_id is not connected to the user's information). IMO client's that would like the know the client_id that the token was issued for, should use the introspection endpoint. 