### PR TITLE
Remove certs from rock

### DIFF
--- a/docker/hydra/hydra.yml
+++ b/docker/hydra/hydra.yml
@@ -30,7 +30,7 @@ strategies:
 
 urls:
   self:
-    issuer: http://hydra:4444
+    issuer: http://localhost:4444
     public: http://localhost:4444
   consent: http://localhost:4455/ui/consent
   login: http://localhost:4455/ui/login

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -19,11 +19,6 @@ services:
     startup: enabled
 
 parts:
-  certificates:
-    plugin: nil
-    stage-packages:
-      - ca-certificates
-
   go-build:
     plugin: go
     source: .


### PR DESCRIPTION
With https://github.com/canonical/identity-platform-login-ui-operator/pull/110 merged, we no longer need to inject the certificates on image build time.

This change reduces the image size from 63MB to 26MB

Closes #251 