### PR TITLE
Add passwordless webauthn support

### DIFF
--- a/docker/kratos/identity.schema.json
+++ b/docker/kratos/identity.schema.json
@@ -59,7 +59,10 @@
                 },
                 "totp": {
                    "account_name": true
-                 }
+                },
+                "webauthn": {
+                  "identifier": true
+                }
               },
               "verification": {
                 "via": "email"

--- a/docker/kratos/kratos.yml
+++ b/docker/kratos/kratos.yml
@@ -69,7 +69,7 @@ selfservice:
                     id: localhost
                     # Set 'origin' to the exact URL of the page that prompts the user to use WebAuthn. You must include the scheme, host, and port.
                     origins:
-                        - http://localhost:4455/ui/
+                        - http://localhost:4455
                     display_name: Canonical
         oidc:
             enabled: True

--- a/docker/kratos/kratos.yml
+++ b/docker/kratos/kratos.yml
@@ -46,6 +46,9 @@ selfservice:
                 oidc:
                     hooks:
                     - hook: session
+                webauthn:
+                    hooks:
+                    - hook: session
     methods:
         totp:
          enabled: true
@@ -57,6 +60,17 @@ selfservice:
                 haveibeenpwned_enabled: false
         code:
             enabled: True
+        webauthn:
+            enabled: True
+            config:
+                passwordless: True
+                rp:
+                    # Set 'id' to the top-level domain.
+                    id: localhost
+                    # Set 'origin' to the exact URL of the page that prompts the user to use WebAuthn. You must include the scheme, host, and port.
+                    origins:
+                        - http://localhost:4455/ui/
+                    display_name: Canonical
         oidc:
             enabled: True
             config:

--- a/pkg/kratos/service.go
+++ b/pkg/kratos/service.go
@@ -19,12 +19,13 @@ import (
 )
 
 const (
-	IncorrectCredentials = 4000006
-	InactiveAccount      = 4000010
-	InvalidRecoveryCode  = 4060006
-	RecoveryCodeSent     = 1060003
-	InvalidProperty      = 4000002
-	InvalidAuthCode      = 4000008
+	IncorrectCredentials    = 4000006
+	InactiveAccount         = 4000010
+	InvalidRecoveryCode     = 4060006
+	RecoveryCodeSent        = 1060003
+	InvalidProperty         = 4000002
+	InvalidAuthCode         = 4000008
+	MissingSecurityKeySetup = 4000015
 )
 
 type Service struct {
@@ -415,6 +416,8 @@ func (s *Service) getUiError(responseBody io.ReadCloser) (err error) {
 		err = fmt.Errorf("invalid %s", errorCodes[0].Context["property"])
 	case InvalidAuthCode:
 		err = fmt.Errorf("invalid authentication code")
+	case MissingSecurityKeySetup:
+		err = fmt.Errorf("choose a different login method")
 	default:
 		err = fmt.Errorf("unknown error")
 		s.logger.Debugf("Kratos error code: %v", errorCode)

--- a/pkg/kratos/service.go
+++ b/pkg/kratos/service.go
@@ -544,6 +544,17 @@ func (s *Service) ParseLoginFlowMethodBody(r *http.Request) (*kClient.UpdateLogi
 			body,
 		)
 		ret.UpdateLoginFlowWithTotpMethod.Method = "totp"
+	case "webauthn":
+		body := new(kClient.UpdateLoginFlowWithWebAuthnMethod)
+
+		err := parseBody(r.Body, &body)
+
+		if err != nil {
+			return nil, err
+		}
+		ret = kClient.UpdateLoginFlowWithWebAuthnMethodAsUpdateLoginFlowBody(
+			body,
+		)
 	// method field is empty for oidc: https://github.com/ory/kratos/pull/3564
 	default:
 		body := new(kClient.UpdateLoginFlowWithOidcMethod)
@@ -620,6 +631,17 @@ func (s *Service) ParseSettingsFlowMethodBody(r *http.Request) (*kClient.UpdateS
 		}
 
 		ret = kClient.UpdateSettingsFlowWithTotpMethodAsUpdateSettingsFlowBody(
+			body,
+		)
+	case "webauthn":
+		body := new(kClient.UpdateSettingsFlowWithWebAuthnMethod)
+
+		err := parseBody(r.Body, &body)
+
+		if err != nil {
+			return nil, err
+		}
+		ret = kClient.UpdateSettingsFlowWithWebAuthnMethodAsUpdateSettingsFlowBody(
 			body,
 		)
 	}

--- a/ui/components/Flow.tsx
+++ b/ui/components/Flow.tsx
@@ -21,7 +21,7 @@ export type Values = Partial<
   | UpdateVerificationFlowBody
 >;
 
-export type Methods = "oidc" | "password" | "code" | "totp";
+export type Methods = "oidc" | "password" | "code" | "totp" | "webauthn";
 
 export interface Props<T> {
   // The flow

--- a/ui/components/NodeInput.tsx
+++ b/ui/components/NodeInput.tsx
@@ -8,6 +8,7 @@ import React, { FC } from "react";
 import { NodeInputText } from "./NodeInputText";
 import { NodeInputPassword } from "./NodeInputPassword";
 import { NodeInputEmail } from "./NodeInputEmail";
+import { NodeInputUrl } from "./NodeInputUrl";
 
 export const NodeInputOIDC: FC<NodeInputProps> = ({
   attributes,
@@ -53,6 +54,8 @@ export const NodeInput: FC<NodeInputProps> = (props) => {
       return <NodeInputEmail {...props} />;
     case "password":
       return <NodeInputPassword {...props} />;
+    case "url":
+      return <NodeInputUrl {...props} />;
     case "submit":
       if (props.node.group === "oidc") {
         return <NodeInputOIDC {...props} />;

--- a/ui/components/NodeInputButton.tsx
+++ b/ui/components/NodeInputButton.tsx
@@ -3,6 +3,20 @@ import { Button } from "@canonical/react-components";
 import React, { FC, FormEvent } from "react";
 import { NodeInputProps } from "./helpers";
 
+const getWebAuthnPayload = (evalCode: string): unknown => {
+  const tmp = evalCode
+    .replace("window.__oryWebAuthnRegistration(", "")
+    .replace("window.__oryWebAuthnLogin(", "");
+  const raw = tmp.substring(0, tmp.length - 1);
+  return JSON.parse(raw) as unknown;
+};
+
+interface WebauthnWindow extends Window {
+  __oryWebAuthnRegistration: (a: unknown) => void;
+  __oryWebAuthnLogin: (a: unknown) => void;
+  __oryStartedLogin: boolean;
+}
+
 export const NodeInputButton: FC<NodeInputProps> = ({
   node,
   attributes,
@@ -10,13 +24,96 @@ export const NodeInputButton: FC<NodeInputProps> = ({
   disabled,
   dispatchSubmit,
 }) => {
+  const onClick = attributes.onclick ?? "";
+
+  const startWebAuthnLogin = () => {
+    const webauthnWindow = window as unknown as WebauthnWindow;
+    const loginParams = getWebAuthnPayload(onClick);
+
+    if (webauthnWindow.__oryStartedLogin) {
+      return;
+    }
+    webauthnWindow.__oryStartedLogin = true;
+
+    // retry login until the webauthn.js script is finished loading
+    // and the __oryWebAuthnLogin function is available
+    const triggerWebauthnLogin = (count: number) =>
+      setTimeout(() => {
+        if ("__oryWebAuthnLogin" in webauthnWindow) {
+          webauthnWindow.__oryWebAuthnLogin(loginParams);
+        } else if (count < 100) {
+          triggerWebauthnLogin(count + 1);
+        }
+      }, 100);
+
+    triggerWebauthnLogin(0);
+  };
+
+  // automatically start the webauthn login
+  if (
+    onClick?.startsWith("window.__oryWebAuthnLogin(") &&
+    getNodeLabel(node) === "Continue"
+  ) {
+    startWebAuthnLogin();
+  }
+
   const handleClick = (e: MouseEvent | FormEvent) => {
+    // webauthn has a custom handler in webauthn.js to be called
+    // preventing the call of eval with below code
+    if (onClick?.startsWith("window.__oryWebAuthnRegistration(")) {
+      e.stopPropagation();
+      e.preventDefault();
+
+      const nameSelector = '*[name="webauthn_register_displayname"]';
+      const name = document.querySelector(nameSelector) as HTMLInputElement;
+
+      if (!name?.value) {
+        name.classList.add("is-error");
+        name.setAttribute("aria-invalid", "true");
+        name.setAttribute("aria-errormessage", "Required field");
+
+        if (!name.nextElementSibling) {
+          const warning = document.createElement("p");
+          warning.className = "p-form-validation__message";
+          warning.textContent = "Required field";
+          name.after(warning);
+        }
+
+        const groupSelector = ".p-form-validation";
+        const group = document.querySelectorAll(groupSelector);
+        group.forEach((e) => e.classList.add("is-error"));
+
+        return;
+      }
+
+      const webauthnWindow = window as unknown as WebauthnWindow;
+      const registrationParams = getWebAuthnPayload(onClick);
+      webauthnWindow.__oryWebAuthnRegistration(registrationParams);
+
+      return;
+    }
+
+    if (onClick?.startsWith("window.__oryWebAuthnLogin(")) {
+      e.stopPropagation();
+      e.preventDefault();
+
+      const webauthnWindow = window as unknown as WebauthnWindow;
+      const loginParams = getWebAuthnPayload(onClick);
+      webauthnWindow.__oryWebAuthnLogin(loginParams);
+
+      return;
+    }
+
     void setValue(attributes.value as string).then(() => dispatchSubmit(e));
   };
 
   return (
     <>
-      <Button onClick={handleClick} disabled={attributes.disabled || disabled}>
+      <Button
+        onClick={handleClick}
+        disabled={attributes.disabled || disabled}
+        name={attributes.name}
+      >
         {getNodeLabel(node)}
       </Button>
     </>

--- a/ui/components/NodeInputPassword.tsx
+++ b/ui/components/NodeInputPassword.tsx
@@ -13,7 +13,15 @@ export const NodeInputPassword: FC<NodeInputProps> = ({
   return (
     <Input
       type="password"
-      label={getNodeLabel(node)}
+      label={
+        <>
+          <span>{getNodeLabel(node)}</span>
+          <a href="./reset_email" style={{ float: "right" }}>
+            Reset password
+          </a>
+        </>
+      }
+      labelClassName="password-label"
       disabled={disabled}
       defaultValue={node.messages.map(({ text }) => text).join(" ")}
       error={error}

--- a/ui/components/NodeInputSubmit.tsx
+++ b/ui/components/NodeInputSubmit.tsx
@@ -39,7 +39,8 @@ export const NodeInputSubmit: FC<NodeInputProps> = ({
       appearance={
         node.group === "password" ||
         node.group === "code" ||
-        node.group === "totp"
+        node.group === "totp" ||
+        node.group === "webauthn"
           ? "positive"
           : ""
       }

--- a/ui/components/NodeInputText.tsx
+++ b/ui/components/NodeInputText.tsx
@@ -11,16 +11,21 @@ export const NodeInputText: FC<NodeInputProps> = ({
   dispatchSubmit,
   error,
 }) => {
+  const urlParams = new URLSearchParams(window.location.search);
+  const isWebauthn = urlParams.get("webauthn") === "true";
+
   return (
     <Input
       type="text"
+      name={attributes.name}
       label={getNodeLabel(node)}
       disabled={disabled}
       defaultValue={node.messages.map(({ text }) => text).join(" ")}
       error={
         attributes.name === "code" ||
         attributes.name === "totp" ||
-        attributes.name === "totp_code"
+        attributes.name === "totp_code" ||
+        (isWebauthn && attributes.name === "identifier")
           ? error
           : undefined
       }

--- a/ui/components/NodeInputUrl.tsx
+++ b/ui/components/NodeInputUrl.tsx
@@ -1,0 +1,33 @@
+import { Button } from "@canonical/react-components";
+import React, { FC } from "react";
+import { NodeInputProps } from "./helpers";
+
+export const NodeInputUrl: FC<NodeInputProps> = ({ node }) => {
+  return (
+    <Button
+      onClick={(e) => {
+        e.preventDefault();
+        e.stopPropagation();
+
+        // read email from input field
+        const email =
+          (
+            document.querySelector(
+              'input[name="identifier"]',
+            ) as HTMLInputElement
+          )?.value || "";
+
+        // redirect to page with same url as current page, append webauthn query param
+        window.location.href = `${window.location.href}&webauthn=true&email=${email}`;
+      }}
+      className="oidc-login-button"
+    >
+      <img
+        src="logos/Fallback.svg"
+        alt="passkey logo"
+        style={{ marginRight: "0.5rem" }}
+      />
+      <span>{node.meta.label?.text}</span>
+    </Button>
+  );
+};

--- a/ui/components/NodeInputUrl.tsx
+++ b/ui/components/NodeInputUrl.tsx
@@ -1,30 +1,33 @@
 import { Button } from "@canonical/react-components";
-import React, { FC } from "react";
+import React, { FC, useCallback } from "react";
 import { NodeInputProps } from "./helpers";
 
 export const NodeInputUrl: FC<NodeInputProps> = ({ node }) => {
+  const isWebauthnLogin = node.meta.label?.text === "Sign in with Security key";
+
+  const handleWebauthnLogin = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+
+      const email =
+        (document.querySelector('input[name="identifier"]') as HTMLInputElement)
+          ?.value || "";
+
+      // redirect to page with same url as current page, append webauthn and email params
+      window.location.href = `${window.location.href}&webauthn=true&email=${email}`;
+    },
+    [node],
+  );
+
   return (
     <Button
-      onClick={(e) => {
-        e.preventDefault();
-        e.stopPropagation();
-
-        // read email from input field
-        const email =
-          (
-            document.querySelector(
-              'input[name="identifier"]',
-            ) as HTMLInputElement
-          )?.value || "";
-
-        // redirect to page with same url as current page, append webauthn query param
-        window.location.href = `${window.location.href}&webauthn=true&email=${email}`;
-      }}
-      className="oidc-login-button"
+      onClick={isWebauthnLogin ? handleWebauthnLogin : undefined}
+      className={isWebauthnLogin ? "oidc-login-button" : ""}
     >
       <img
         src="logos/Fallback.svg"
-        alt="passkey logo"
+        alt="iconography of a key"
         style={{ marginRight: "0.5rem" }}
       />
       <span>{node.meta.label?.text}</span>

--- a/ui/pages/login.tsx
+++ b/ui/pages/login.tsx
@@ -1,4 +1,9 @@
-import { LoginFlow, UpdateLoginFlowBody } from "@ory/client";
+import {
+  LoginFlow,
+  UiNode,
+  UiNodeInputAttributes,
+  UpdateLoginFlowBody,
+} from "@ory/client";
 import { Spinner } from "@canonical/react-components";
 import { AxiosError } from "axios";
 import type { NextPage } from "next";
@@ -78,6 +83,9 @@ const Login: NextPage = () => {
         if ((values as UpdateLoginFlowWithOidcMethod).provider) {
           return "oidc";
         }
+        if (values.method === "webauthn") {
+          return "webauthn";
+        }
         if (isAuthCode) {
           return "totp";
         }
@@ -135,10 +143,85 @@ const Login: NextPage = () => {
     ? "Verify your identity"
     : `Sign in${getTitleSuffix()}`;
   const renderFlow = isAuthCode ? replaceAuthLabel(flow) : flow;
+
+  let isWebauthn = false;
+  if (renderFlow?.ui) {
+    const urlParams = new URLSearchParams(window.location.search);
+    isWebauthn =
+      urlParams.get("webauthn") === "true" ||
+      renderFlow.ui.nodes.filter(
+        (node) => node.group !== "webauthn" && node.group !== "default",
+      ).length === 0;
+
+    renderFlow.ui.nodes = renderFlow?.ui.nodes.filter((node) => {
+      // show webauthn elements in dedicated step after it is selected
+      if (isWebauthn) {
+        return node.group === "webauthn" || node.group === "default";
+      }
+      // hide webauthn everywhere else
+      return node.group !== "webauthn";
+    });
+
+    // add security key option that looks like an oidc input
+    if (!isWebauthn && !isAuthCode) {
+      renderFlow.ui.nodes.push({
+        attributes: {
+          type: "url",
+          node_type: "input",
+          name: "",
+          disabled: false,
+        },
+        group: "webauthn",
+        type: "input",
+        messages: [],
+        meta: {
+          label: {
+            id: 1,
+            text: "Sign in with Security key",
+            type: "info",
+          },
+        },
+      });
+    }
+
+    // ensure oidc options are presented after username/password inputs
+    renderFlow.ui.nodes.sort((a, b) => {
+      const toValue = (node: UiNode) => (node.group === "oidc" ? 1 : -1);
+      return toValue(a) - toValue(b);
+    });
+
+    // autosubmit webauthn in case email is provided
+    const email = urlParams.get("email");
+    if (isWebauthn && email) {
+      const csrfNode = renderFlow?.ui.nodes.find(
+        (node) =>
+          node.group === "default" &&
+          node.attributes.node_type === "input" &&
+          node.attributes.name === "csrf_token",
+      )?.attributes as UiNodeInputAttributes;
+
+      void handleSubmit({
+        method: "webauthn",
+        identifier: email,
+        csrf_token: (csrfNode.value as string) ?? "",
+      }).catch(() => {
+        if (flow?.return_to) {
+          window.location.href = flow.return_to;
+        }
+      });
+
+      return null;
+    }
+  }
+
+  if (!flow) {
+    return;
+  }
+
   return (
     <PageLayout title={title}>
       {flow ? <Flow onSubmit={handleSubmit} flow={renderFlow} /> : <Spinner />}
-      <a href="./reset_email">Reset password</a>
+      {isWebauthn && <a href={flow?.return_to}>I want to use another method</a>}
     </PageLayout>
   );
 };

--- a/ui/pages/setup_passkey.tsx
+++ b/ui/pages/setup_passkey.tsx
@@ -1,0 +1,129 @@
+import {
+  SettingsFlow,
+  UpdateSettingsFlowBody,
+  UpdateSettingsFlowWithWebAuthnMethod,
+} from "@ory/client";
+import type { NextPage } from "next";
+import { useRouter } from "next/router";
+import { useEffect, useState, useCallback } from "react";
+import React from "react";
+import { handleFlowError } from "../util/handleFlowError";
+import { Flow } from "../components/Flow";
+import { kratos } from "../api/kratos";
+import PageLayout from "../components/PageLayout";
+import { AxiosError } from "axios";
+import { Spinner } from "@canonical/react-components";
+import { UiNodeInputAttributes } from "@ory/client/api";
+import Head from "next/head";
+
+const SetupPasskey: NextPage = () => {
+  const [flow, setFlow] = useState<SettingsFlow>();
+
+  // Get ?flow=... from the URL
+  const router = useRouter();
+  const { return_to: returnTo, flow: flowId } = router.query;
+
+  useEffect(() => {
+    // If the router is not ready yet, or we already have a flow, do nothing.
+    if (!router.isReady || flow) {
+      return;
+    }
+
+    // If ?flow=... was in the URL, we fetch it
+    if (flowId) {
+      kratos
+        .getSettingsFlow({ id: String(flowId) })
+        .then((res) => setFlow(res.data))
+        .catch(handleFlowError("settings", setFlow));
+      return;
+    }
+
+    // Otherwise we initialize it
+    kratos
+      .createBrowserSettingsFlow({
+        returnTo: returnTo ? String(returnTo) : undefined,
+      })
+      .then(({ data }) => {
+        if (data.request_url !== undefined) {
+          window.location.href = `./setup_passkey?flow=${data.id}`;
+          return;
+        }
+        setFlow(data);
+      })
+      .catch(handleFlowError("settings", setFlow))
+      .catch(async (err: AxiosError<string>) => {
+        if (err.response?.data.trim() === "Failed to create settings flow") {
+          setFlow(undefined);
+          await router.push("./login");
+          return;
+        }
+
+        return Promise.reject(err);
+      });
+  }, [flowId, router, router.isReady, returnTo, flow]);
+
+  const handleSubmit = useCallback(
+    (values: UpdateSettingsFlowBody) => {
+      const methodValues = values as UpdateSettingsFlowWithWebAuthnMethod;
+      console.log(values);
+      return kratos
+        .updateSettingsFlow({
+          flow: String(flow?.id),
+          updateSettingsFlowBody: {
+            csrf_token: (flow?.ui?.nodes[0].attributes as UiNodeInputAttributes)
+              .value as string,
+            method: "webauthn",
+            webauthn_register_displayname:
+              methodValues.webauthn_register_displayname,
+            webauthn_register: methodValues.webauthn_register,
+          },
+        })
+        .then(async ({ data }) => {
+          if (flow?.state === "success") {
+            await router.push("./setup_complete");
+          }
+          if ("redirect_to" in data) {
+            window.location.href = data.redirect_to as string;
+            return;
+          }
+          if (flow?.return_to) {
+            window.location.href = flow.return_to;
+            return;
+          }
+          await router.push("./error");
+        })
+        .catch(handleFlowError("settings", setFlow));
+    },
+    [flow, router],
+  );
+
+  const webauthnFlow = {
+    ...flow,
+    ui: {
+      ...flow?.ui,
+      nodes: flow?.ui.nodes.filter(({ group }) => {
+        return group === "webauthn";
+      }),
+    },
+  } as SettingsFlow;
+
+  // TODO: The webauthn script should be launched on submit
+  return (
+    <PageLayout title="Set up a passkey login method">
+      <Head>
+        <script
+          src="http://localhost:4433/.well-known/ory/webauthn.js"
+          type="script"
+          async
+        />
+      </Head>
+      {flow ? (
+        <Flow onSubmit={handleSubmit} flow={webauthnFlow} />
+      ) : (
+        <Spinner />
+      )}
+    </PageLayout>
+  );
+};
+
+export default SetupPasskey;

--- a/ui/pages/setup_passkey.tsx
+++ b/ui/pages/setup_passkey.tsx
@@ -62,7 +62,8 @@ const SetupPasskey: NextPage = () => {
   }, [flowId, router, router.isReady, returnTo, flow]);
 
   const handleSubmit = (values: UpdateSettingsFlowBody) => {
-    // this is handled by the webauthn script
+    // adding a new key is handled by NodeInputButton that triggers the webauthn script
+    // here we only handle removal of a key
     const authValues = values as UpdateSettingsFlowWithWebAuthnMethod;
     if (authValues.webauthn_remove) {
       return kratos

--- a/ui/static/sass/styles.scss
+++ b/ui/static/sass/styles.scss
@@ -33,3 +33,7 @@ $breakpoint-navigation-threshold: 820px;
   padding: 0.5rem;
   width: 100%;
 }
+
+.password-label {
+  width: 100%;
+}


### PR DESCRIPTION
### Testing
```
make npm-build build

export KRATOS_PUBLIC_URL="http://localhost:4433"
export HYDRA_ADMIN_URL="http://localhost:4445"
export BASE_URL="http://localhost:4455"
export PORT="4455"
export TRACING_ENABLED="false"
export LOG_LEVEL="debug"
export AUTHORIZATION_ENABLED="false"

go run . serve

docker-compose -f docker-compose.dev.yml up --build --force-recreate --remove-orphans
```

```
docker exec <hydra-container> \
  hydra create client \
    --endpoint http://127.0.0.1:4445 \
    --name grafana \
    --grant-type authorization_code,refresh_token \
    --response-type code,id_token \
    --format json \
    --scope openid,offline_access,email \
    --redirect-uri http://localhost:2345/login/generic_oauth

docker run -d --name=grafana -p 2345:2345 --network identity-platform-login-ui_intranet \
-e "GF_SERVER_HTTP_PORT=2345" \
-e "GF_AUTH_GENERIC_OAUTH_ENABLED=true" \
-e "GF_AUTH_GENERIC_OAUTH_AUTH_ALLOWED_DOMAINS=hydra,localhost" \
-e "GF_AUTH_GENERIC_OAUTH_NAME=Identity Platform" \
-e "GF_AUTH_GENERIC_OAUTH_CLIENT_ID=<client-id>" \
-e "GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET=<client-secret>" \
-e "GF_AUTH_GENERIC_OAUTH_SCOPES=openid offline_access email" \
-e "GF_AUTH_GENERIC_OAUTH_AUTH_URL=http://localhost:4444/oauth2/auth" \
-e "GF_AUTH_GENERIC_OAUTH_TOKEN_URL=http://hydra:4444/oauth2/token" \
-e "GF_AUTH_GENERIC_OAUTH_API_URL=http://hydra:4444/userinfo" \
grafana/grafana
```
Go to localhost:2345 and sign in (`test@example.com / test`), then connect the account with a passkey at localhost:4455/ui/setup_passkey:
![image](https://github.com/user-attachments/assets/146d497d-c0f9-42fb-9c8e-99902cb3213f)

Open a new browser session and sign in with passkey:
![image](https://github.com/user-attachments/assets/13419214-2b5d-417d-a84c-cfc254e9a10c)

![image](https://github.com/user-attachments/assets/5d7fcd1d-dd52-4d7c-99d9-6c6f00059316)

Use `test@example.com` account to sign in:
![image](https://github.com/user-attachments/assets/3f842b8b-9fa3-41db-a784-1abd6c6c4423)

![image](https://github.com/user-attachments/assets/41cf7879-8472-48a1-b588-8be202c91de0)

![image](https://github.com/user-attachments/assets/5ed1bbc8-ba96-4f76-b1cc-74fd0843dfc0)

If request is cancelled:
![image](https://github.com/user-attachments/assets/ebded33c-1c43-4c4d-a941-fe061c2f4740)