### PR TITLE
poc: ldap integration

### DIFF
--- a/docker-compose.ldap.yml
+++ b/docker-compose.ldap.yml
@@ -1,0 +1,73 @@
+version: "3.7"
+include:
+  - docker-compose.dev.yml
+services:
+    hydra-client:
+        image: curlimages/curl:7.81.0
+        command: |
+            -X POST http://hydra-ldap:4445/admin/clients
+            -H 'Content-Type: application/json'
+            -d '{
+                "client_id": "test-client",
+                "client_secret": "test-secret",
+                "scope": "openid profile email roles",
+                "redirect_uris": ["http://localhost:4433/self-service/methods/oidc/callback/LDAP"]
+            }'
+        networks:
+            - intranet
+        restart: on-failure
+        depends_on:
+            - hydra-ldap
+        healthcheck:
+            test: ["CMD", "curl", "-f", "http://hydra-ldap:4445"]
+            interval: 10s
+            timeout: 10s
+            retries: 10
+    hydra-ldap:
+        image: oryd/hydra:v2.2.0
+        command: serve -c /etc/config/hydra/hydra.ldap.yml all --dev
+        volumes:
+          - type: bind
+            source: ./docker/hydra
+            target: /etc/config/hydra
+        networks:
+            - intranet
+        ports:
+            - "4464:4444"
+            - "4465:4445"
+        deploy:
+            restart_policy:
+                condition: on-failure
+        depends_on:
+            - werther
+    werther:
+        image: nsklikas/werther:latest
+        environment:
+            WERTHER_IDENTP_HYDRA_URL: http://hydra-ldap:4445
+            WERTHER_LDAP_ENDPOINTS: ldap:389
+            WERTHER_LDAP_BINDDN: cn=admin,dc=example,dc=com
+            WERTHER_LDAP_BINDPW: password
+            WERTHER_LDAP_BASEDN: "dc=example,dc=com"
+            WERTHER_LDAP_ROLE_BASEDN: "ou=AppRoles,dc=example,dc=com"
+        networks:
+            - intranet
+        ports:
+            - "8082:8080"
+        deploy:
+            restart_policy:
+                condition: on-failure
+        depends_on:
+            - ldap
+    ldap:
+        image: pgarrett/ldap-alpine
+        volumes:
+            - "./docker/ldap:/ldif/"
+        networks:
+            - intranet
+        ports:
+            - "389:389"
+        deploy:
+            restart_policy:
+                condition: on-failure
+networks:
+    intranet:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 version: '3.7'
 include:
-  - docker-compose.dev.yml
+  - docker-compose.ldap.yml
 services:
   identity-platform-login-ui:
     image: ghcr.io/canonical/identity-platform-login-ui:latest

--- a/docker/hydra/hydra.ldap.yml
+++ b/docker/hydra/hydra.ldap.yml
@@ -1,0 +1,49 @@
+serve:
+  cookies:
+    same_site_mode: Strict
+    names:
+      login_csrf: "hydra_ldap"
+      consent_csrf: "hydra_ldap"
+      session: "hydra_ldap"
+  admin:
+    cors:
+      enabled: true
+      allowed_origins:
+        - "*"
+  public:
+    cors:
+      enabled: true
+      allowed_origins:
+        - "*"
+
+log:
+  leak_sensitive_values: true
+  level: debug
+
+oauth2:
+  expose_internal_errors: true
+
+strategies:
+  access_token: jwt
+  jwt:
+    scope_claim: list
+  scope: exact
+
+urls:
+  self:
+    issuer: http://hydra-ldap:4444
+    public: http://localhost:4464
+  consent: http://localhost:8082/auth/consent
+  login: http://localhost:8082/auth/login
+  error: http://localhost:8082/auth/oidc_error
+
+webfinger:
+  oidc_discovery:
+    token_url: http://hydra-ldap:4444/oauth2/token
+    auth_url: http://localhost:4464/oauth2/auth
+
+dsn: memory
+
+secrets:
+  system:
+    - youReallyNeedToChangeThis

--- a/docker/kratos/kratos.yml
+++ b/docker/kratos/kratos.yml
@@ -86,6 +86,14 @@ selfservice:
                   mapper_url: "file:///etc/config/kratos/schema.jsonnet"
                   scope: ["user:email"]
                   label: Github
+                - id: "LDAP"
+                  provider: "generic"
+                  mapper_url: "file:///etc/config/kratos/schema.jsonnet"
+                  scope: ["openid", "profile", "email", "roles"]
+                  label: LDAP
+                  issuer_url: http://hydra-ldap:4444
+                  client_id: test-client
+                  client_secret: test-secret
 courier:
     smtp:
         connection_uri: smtps://test:test@mailslurper:1025/?skip_ssl_verify=true

--- a/docker/ldap/ldap.ldif
+++ b/docker/ldap/ldap.ldif
@@ -1,0 +1,25 @@
+dn: uid=aaa,ou=Users,dc=example,dc=com
+objectClass: inetOrgPerson
+cn: John Doe
+sn: Doe
+uid: aaa
+userPassword: 123
+mail: a@a.com
+ou: Users
+
+dn: ou=AppRoles,dc=example,dc=com
+objectClass: organizationalunit
+ou: AppRoles
+description: AppRoles
+
+dn: ou=App1,ou=AppRoles,dc=example,dc=com
+objectClass: organizationalunit
+ou: App1
+description: App1
+
+dn: cn=traveler,ou=App1,ou=AppRoles,dc=example,dc=com
+objectClass: groupofnames
+cn: traveler
+description: traveler
+member: uid=aaa,ou=Users,dc=example,dc=com
+


### PR DESCRIPTION
PoC for using Hydra to integrate ldap with Kratos.

The [werther](https://github.com/i-core/werther) project is used to bridge Hydra and LDAP servers. The project is unmaintained, but it proves that it shouldn't be very hard to implement this functionality.

Werther was using the hydra sdk v1, so I had to make some changes to the code (see [here](https://github.com/nsklikas/werther/commit/86ef0950dcc01403663269cf6355cd73b43f1a31))

As discussed, the proposed architecture uses a 2nd hydra server (using different cookie names) that runs behind Kratos that is used to talk with LDAP.

To try the flow, you need to run:
```console
$ docker compose  up --remove-orphans --force-recreate
```

When everything is up and running you can try to login via hydra, to do this you can use this script:
```bash
code_client=$(hydra create client \
  --endpoint http://localhost:4445 \
  --grant-type authorization_code,refresh_token,urn:ietf:params:oauth:grant-type:device_code \
  --response-type code \
  --format json \
  --scope openid,offline_access,email,profile \
  --redirect-uri http://127.0.0.1:4446/callback \
)
hydra perform authorization-code \
  --endpoint http://localhost:4444 \
  --client-id `echo "$code_client" | yq .client_id` \
  --client-secret  `echo "$code_client" | yq .client_secret` \
  --scope openid,profile,email,offline_access \
  --redirect http://127.0.0.1:4446/callback
```

To login with LDAP you can use:
username: `aaa`
password: `123`

The user attributes can be found at https://github.com/canonical/identity-platform-login-ui/blob/IAM-1015/docker/ldap/ldap.ldif