### PR TITLE
Fix redirect on first login

### DIFF
--- a/pkg/kratos/handlers_test.go
+++ b/pkg/kratos/handlers_test.go
@@ -905,6 +905,7 @@ func TestHandleCreateSettingsFlow(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodGet, HANDLE_CREATE_SETTINGS_FLOW_URL, nil)
 	values := req.URL.Query()
+	values.Set("return_to", redirect)
 	req.URL.RawQuery = values.Encode()
 
 	flow := kClient.NewSettingsFlowWithDefaults()
@@ -941,6 +942,7 @@ func TestHandleCreateSettingsFlowWithRedirect(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodGet, HANDLE_CREATE_SETTINGS_FLOW_URL, nil)
 	values := req.URL.Query()
+	values.Set("return_to", redirect)
 	req.URL.RawQuery = values.Encode()
 
 	flow := kClient.NewSettingsFlowWithDefaults()
@@ -974,6 +976,7 @@ func TestHandleCreateSettingsFlowFailOnCreateBrowserSettingsFlow(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodGet, HANDLE_CREATE_SETTINGS_FLOW_URL, nil)
 	values := req.URL.Query()
+	values.Set("return_to", redirect)
 	req.URL.RawQuery = values.Encode()
 
 	mockService.EXPECT().CreateBrowserSettingsFlow(gomock.Any(), redirect, req.Cookies()).Return(nil, nil, fmt.Errorf("error"))


### PR DESCRIPTION
IAM-1039

The issue is fixed by passing the original return to, to the settings flow. I moved some stuff around, to more clearly separate the responsibilities of the frontend and the backend. 

There is some reload happening in the `setup_secure` page when you get there (you momentarily see the spinning thingy). Not sure how to fix it (@edlerd please have a look)

SInce Natalia is not here this week @edlerd and @BarcoMasile please try it out, as I may have broken something
