### PR TITLE
Fix backup codes setup

### DIFF
--- a/pkg/kratos/service.go
+++ b/pkg/kratos/service.go
@@ -163,11 +163,15 @@ func (s *Service) CreateBrowserSettingsFlow(ctx context.Context, returnTo string
 	ctx, span := s.tracer.Start(ctx, "kratos.Service.CreateBrowserSettingsFlow")
 	defer span.End()
 
-	flow, resp, err := s.kratos.FrontendApi().
+	request := s.kratos.FrontendApi().
 		CreateBrowserSettingsFlow(ctx).
-		ReturnTo(returnTo).
-		Cookie(httpHelpers.CookiesToString(cookies)).
-		Execute()
+		Cookie(httpHelpers.CookiesToString(cookies))
+
+	if returnTo != "" {
+		request = request.ReturnTo(returnTo)
+	}
+
+	flow, resp, err := request.Execute()
 
 	// 403 means the user must be redirected to complete second factor auth
 	// in order to access settings

--- a/ui/pages/setup_backup_codes.tsx
+++ b/ui/pages/setup_backup_codes.tsx
@@ -88,11 +88,11 @@ const SetupBackupCodes: NextPage = () => {
               : undefined,
           },
         })
-        .then(() => {
+        .then((res) => {
           if (methodValues.lookup_secret_confirm) {
             window.location.href = "./setup_complete";
           } else {
-            setFlow(undefined); // Reset the flow to trigger refresh
+            setFlow(res.data); // Reset the flow to trigger refresh
           }
         })
         .catch(handleFlowError("settings", setFlow));


### PR DESCRIPTION
After the recent changes, setting up the backup codes was broken.

If you clicked on the `generate backup codes` button, nothing would happen. This PR fixes that