### PR TITLE
fix backup codes download was broken due to content security policy

### DIFF
--- a/pkg/ui/handlers.go
+++ b/pkg/ui/handlers.go
@@ -35,7 +35,7 @@ func (a *API) RegisterEndpoints(mux *chi.Mux) {
 		w.Header().Set("X-Frame-Options", "SAMEORIGIN")
 		// Sets the Content Security Policy (CSP) for the page, which helps mitigate XSS attacks and data injection attacks.
 		// The policy allows loading resources (scripts, styles, images, etc.) only from the same origin ('self'), data URLs, and all subdomains of ubuntu.com.
-		w.Header().Set("Content-Security-Policy", "default-src 'self' data: https://*.ubuntu.com; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'")
+		w.Header().Set("Content-Security-Policy", "default-src 'self' data: https://*.ubuntu.com; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'")
 
 		// `no-store`: This will tell any cache system not to cache the index.html file
 		// `no-cache`: This will tell any cache system to check if there is a newer version in the server


### PR DESCRIPTION
# Done
- fix backup codes download was broken due to content security policy being too strict.

fixes #314