### PR TITLE
improve ui for reset password

### DIFF
--- a/ui/components/NodeInputEmail.tsx
+++ b/ui/components/NodeInputEmail.tsx
@@ -14,17 +14,26 @@ export const NodeInputEmail: FC<NodeInputProps> = ({
   const [hasLocalValidation, setLocalValidation] = React.useState(false);
 
   const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-  const isInvalid = !emailRegex.test((value as string) ?? "");
+  const isInvalid = !emailRegex.test((value as string) ?? "") && value !== "";
   const localError = isInvalid ? "Incorrect email address" : undefined;
+  const message = node.messages.map(({ text }) => text).join(" ");
+  const defaultValue = message.includes('is not valid "email"')
+    ? message.split('"')[1]
+    : message;
 
   const error = hasLocalValidation ? localError : upstreamError;
+
+  if (value == undefined) {
+    void setValue(defaultValue);
+  }
 
   return (
     <Input
       type="email"
       label={getNodeLabel(node)}
       disabled={disabled}
-      defaultValue={node.messages.map(({ text }) => text).join(" ")}
+      defaultValue={defaultValue}
+      autoFocus={true}
       error={error}
       onChange={(e) => void setValue(e.target.value)}
       onBlur={() => setLocalValidation(true)}

--- a/ui/components/NodeInputSubmit.tsx
+++ b/ui/components/NodeInputSubmit.tsx
@@ -42,9 +42,21 @@ export const NodeInputSubmit: FC<NodeInputProps> = ({
   const showTotpLink =
     (node.meta.label as unknown as { hasTotpLink: boolean })?.hasTotpLink ??
     false;
+  const showBackLink = node.meta?.label?.text === "Reset password";
 
   return (
     <>
+      {showBackLink && (
+        <Button
+          tabIndex={3}
+          type="button"
+          onClick={() => {
+            void window.history.back();
+          }}
+        >
+          Back
+        </Button>
+      )}
       <Button
         appearance={
           node.group === "password" ||


### PR DESCRIPTION
# Done
- add the back button (it should just redirect to the login url)
- rename Submit to Reset password
- make sure the field doesn't show the error message once you click on the button

fixes #322

Skipped the "refactor the "Check your email" screen to contain the email address typed in the previous step" as per #322. 
 Because 1. we don't know the email in the 2nd step and 2. the email does not contain any url, only the code to enter. So we need to keep the step with the input box.