### PR TITLE
Return error if no login_challenge or return_to

### DIFF
--- a/pkg/kratos/handlers.go
+++ b/pkg/kratos/handlers.go
@@ -66,6 +66,10 @@ func (a *API) handleCreateFlow(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if returnTo == "" {
+		if loginChallenge == "" {
+			http.Error(w, "One of return_to or login_challenge must be provided", http.StatusBadRequest)
+			return
+		}
 		returnTo, err = a.returnToUrl(loginChallenge)
 		if err != nil {
 			// this should never happen if app is properly configured

--- a/pkg/kratos/handlers_test.go
+++ b/pkg/kratos/handlers_test.go
@@ -35,6 +35,32 @@ const (
 //go:generate mockgen -build_flags=--mod=mod -package kratos -destination ./mock_logger.go -source=../../internal/logging/interfaces.go
 //go:generate mockgen -build_flags=--mod=mod -package kratos -destination ./mock_kratos.go -source=./interfaces.go
 
+func TestHandleCreateFlowWithoutParams(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := NewMockLoggerInterface(ctrl)
+	mockService := NewMockServiceInterface(ctrl)
+
+	flow := kClient.NewLoginFlowWithDefaults()
+	flow.Id = "test"
+
+	req := httptest.NewRequest(http.MethodGet, HANDLE_CREATE_FLOW_URL, nil)
+
+	w := httptest.NewRecorder()
+	mux := chi.NewMux()
+	NewAPI(mockService, false, BASE_URL, mockLogger).RegisterEndpoints(mux)
+
+	mux.ServeHTTP(w, req)
+
+	res := w.Result()
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected HTTP status code 400 got %v", res.StatusCode)
+	}
+}
+
 func TestHandleCreateFlowWithoutSession(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()


### PR DESCRIPTION
IAM-1152

With this change, if you try to access localhost:4455/ui/login, the backend will return an error (400) and the browser will be redirected to the error page.

Closes #329 