### PR TITLE
Check hydra request skip value

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ At the moment the application is sourcing the following from the environment:
   `log.txt`. **Make sure application user has permissions to write**.
 - `PORT` - HTTP server port, defaults to `8080`
 - `BASE_URL` - the base url that the application will be running on
+- `COOKIES_ENCRYPTION_KEY`: 32 bytes string used for encrypting cookies
 - `KRATOS_PUBLIC_URL` - address of Kratos Public APIs
 - `KRATOS_ADMIN_URL` - address of Kratos Admin APIs
 - `HYDRA_ADMIN_URL` - address of Hydra admin APIs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - KRATOS_ADMIN_URL=http://kratos:4434
       - HYDRA_ADMIN_URL=http://hydra:4445
       - BASE_URL=http://localhost:4455
+      - COOKIES_ENCRYPTION_KEY=WrfOcYmVBwyduEbKYTUhO4X7XVaOQ1wF
       - PORT=4455
       - LOG_LEVEL=DEBUG
       - LOG_FILE=/var/log/aba.log

--- a/internal/config/specs.go
+++ b/internal/config/specs.go
@@ -15,6 +15,9 @@ type EnvSpec struct {
 	Port    int    `envconfig:"port" default:"8080"`
 	BaseURL string `envconfig:"base_url" default:""`
 
+	CookiesEncryptionKey string `envconfig:"cookies_encryption_key" required:"true" validate:"required,min=32,max=32"`
+	CookieTTL            int    `envconfig:"cookie_ttl" default:"300"`
+
 	KratosPublicURL string `envconfig:"kratos_public_url"`
 	KratosAdminURL  string `envconfig:"kratos_admin_url"`
 	HydraAdminURL   string `envconfig:"hydra_admin_url"`

--- a/pkg/extra/service.go
+++ b/pkg/extra/service.go
@@ -54,6 +54,7 @@ func (s *Service) AcceptConsent(ctx context.Context, identity kClient.Identity, 
 	r.SetGrantScope(consent.RequestedScope)
 	r.SetGrantAccessTokenAudience(atAudience)
 	r.SetSession(*session)
+	r.SetRemember(true)
 
 	ctx, span := s.tracer.Start(ctx, "hydra.OAuth2Api.AcceptOAuth2ConsentRequest")
 	defer span.End()

--- a/pkg/kratos/cookies.go
+++ b/pkg/kratos/cookies.go
@@ -1,0 +1,124 @@
+// Copyright 2024 Canonical Ltd.
+// SPDX-License-Identifier: AGPL-3.0
+
+package kratos
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/canonical/identity-platform-login-ui/internal/logging"
+)
+
+const (
+	defaultCookiePath = "/"
+	stateCookieName   = "login_ui_state"
+)
+
+var (
+	epoch = time.Unix(0, 0).UTC()
+)
+
+type AuthCookieManager struct {
+	cookieTTL time.Duration
+	encrypt   EncryptInterface
+
+	logger logging.LoggerInterface
+}
+
+type FlowStateCookie struct {
+	LoginChallengeHash string `json:"lc,omitempty"`
+	TotpSetup          bool   `json:"t,omitempty"`
+}
+
+func (a *AuthCookieManager) SetStateCookie(w http.ResponseWriter, state FlowStateCookie) error {
+	rawState, err := json.Marshal(state)
+	if err != nil {
+		return err
+	}
+	return a.setCookie(w, stateCookieName, string(rawState), defaultCookiePath, a.cookieTTL, http.SameSiteLaxMode)
+}
+
+func (a *AuthCookieManager) GetStateCookie(r *http.Request) (FlowStateCookie, error) {
+	var ret FlowStateCookie
+	c, err := a.getCookie(r, stateCookieName)
+	if c == "" || err != nil {
+		return FlowStateCookie{}, err
+	}
+	err = json.Unmarshal([]byte(c), &ret)
+	return ret, err
+}
+
+func (a *AuthCookieManager) ClearStateCookie(w http.ResponseWriter) {
+	a.clearCookie(w, stateCookieName, defaultCookiePath)
+}
+
+func (a *AuthCookieManager) setCookie(w http.ResponseWriter, name, value string, path string, ttl time.Duration, sameSitePolicy http.SameSite) error {
+	if value == "" {
+		return nil
+	}
+
+	expires := time.Now().Add(ttl)
+
+	encrypted, err := a.encrypt.Encrypt(value)
+	if err != nil {
+		a.logger.Errorf("can't encrypt cookie value, %v", err)
+		return err
+	}
+
+	http.SetCookie(w, &http.Cookie{
+		Name:     name,
+		Value:    encrypted,
+		Path:     path,
+		Domain:   "",
+		Expires:  expires,
+		MaxAge:   int(ttl.Seconds()),
+		HttpOnly: true,
+		Secure:   true,
+		SameSite: sameSitePolicy,
+	})
+	return nil
+}
+
+func (a *AuthCookieManager) clearCookie(w http.ResponseWriter, name string, path string) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     name,
+		Value:    "",
+		Path:     path,
+		Domain:   "",
+		Expires:  epoch,
+		MaxAge:   -1,
+		Secure:   true,
+		HttpOnly: true,
+	})
+}
+
+func (a *AuthCookieManager) getCookie(r *http.Request, name string) (string, error) {
+	cookie, err := r.Cookie(name)
+	if err != nil {
+		// This means that the cookie does not exist, not a real error
+		return "", nil
+	}
+
+	value, err := a.encrypt.Decrypt(cookie.Value)
+	if err != nil {
+		a.logger.Errorf("can't decrypt cookie value, %v", err)
+		return "", err
+	}
+	return value, nil
+}
+
+func NewAuthCookieManager(
+	cookieTTLSeconds int,
+	encrypt EncryptInterface,
+	logger logging.LoggerInterface,
+) *AuthCookieManager {
+	a := new(AuthCookieManager)
+	a.cookieTTL = time.Duration(cookieTTLSeconds) * time.Second
+	a.encrypt = encrypt
+
+	a.logger = logger
+	return a
+
+}

--- a/pkg/kratos/cookies_test.go
+++ b/pkg/kratos/cookies_test.go
@@ -1,0 +1,175 @@
+// Copyright 2024 Canonical Ltd.
+// SPDX-License-Identifier: AGPL-3.0
+
+package kratos
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"go.uber.org/mock/gomock"
+)
+
+//go:generate mockgen -build_flags=--mod=mod -package kratos -destination ./mock_logger.go -source=../../internal/logging/interfaces.go
+//go:generate mockgen -build_flags=--mod=mod -package kratos -destination ./mock_interfaces.go -source=./interfaces.go
+//go:generate mockgen -build_flags=--mod=mod -package kratos -destination ./mock_tracing.go go.opentelemetry.io/otel/trace Tracer
+//go:generate mockgen -build_flags=--mod=mod -package kratos -destination ./mock_monitor.go -source=../../internal/monitoring/interfaces.go
+
+func findCookie(name string, cookies []*http.Cookie) (*http.Cookie, bool) {
+	for _, cookie := range cookies {
+		if name == cookie.Name {
+			return cookie, true
+		}
+	}
+
+	return nil, false
+}
+
+func TestAuthCookieManager_ClearStateCookie(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	mockLogger := NewMockLoggerInterface(ctrl)
+	mockEncrypt := NewMockEncryptInterface(ctrl)
+
+	mockRequest := httptest.NewRequest(http.MethodGet, "/", nil)
+	mockRequest.AddCookie(&http.Cookie{Name: "state"})
+
+	mockResponse := httptest.NewRecorder()
+
+	manager := NewAuthCookieManager(5, mockEncrypt, mockLogger)
+	manager.ClearStateCookie(mockResponse)
+
+	c, _ := findCookie("login_ui_state", mockResponse.Result().Cookies())
+
+	if c.Expires != epoch {
+		t.Fatal("did not clear state cookie")
+	}
+}
+
+func TestAuthCookieManager_GetStateCookie(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	mockLogger := NewMockLoggerInterface(ctrl)
+	mockEncrypt := NewMockEncryptInterface(ctrl)
+
+	state := FlowStateCookie{}
+	sj, _ := json.Marshal(state)
+
+	mockEncrypt.EXPECT().Decrypt("mock-state").Return(string(sj), nil)
+
+	mockRequest := httptest.NewRequest(http.MethodGet, "/", nil)
+	mockRequest.AddCookie(&http.Cookie{Name: "login_ui_state", Value: "mock-state"})
+
+	manager := NewAuthCookieManager(5, mockEncrypt, mockLogger)
+	cookie, err := manager.GetStateCookie(mockRequest)
+
+	if cookie != state {
+		t.Fatal("state cookie value does not match expected")
+	}
+
+	if err != nil {
+		t.Fatalf("expected error to be nil not  %v", err)
+	}
+}
+
+func TestAuthCookieManager_GetStateCookieNoCookie(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	mockLogger := NewMockLoggerInterface(ctrl)
+	mockRequest := httptest.NewRequest(http.MethodGet, "/", nil)
+
+	manager := NewAuthCookieManager(5, nil, mockLogger)
+	cookie, err := manager.GetStateCookie(mockRequest)
+
+	state := FlowStateCookie{}
+	if cookie != state {
+		t.Fatal("state cookie value does not match expected")
+	}
+
+	if err != nil {
+		t.Fatalf("expected error to be nil, not %v", err)
+	}
+}
+
+func TestAuthCookieManager_GetStateCookieDecryptFailure(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockError := errors.New("mock-error")
+
+	mockLogger := NewMockLoggerInterface(ctrl)
+	mockLogger.EXPECT().Errorf("can't decrypt cookie value, %v", mockError).Times(1)
+
+	mockEncrypt := NewMockEncryptInterface(ctrl)
+	mockEncrypt.EXPECT().Decrypt("mock-state").Return("", mockError)
+
+	mockRequest := httptest.NewRequest(http.MethodGet, "/", nil)
+	mockRequest.AddCookie(&http.Cookie{Name: "login_ui_state", Value: "mock-state"})
+
+	manager := NewAuthCookieManager(5, mockEncrypt, mockLogger)
+	cookie, err := manager.GetStateCookie(mockRequest)
+
+	state := FlowStateCookie{}
+	if cookie != state {
+		t.Fatal("state cookie value does not match expected")
+	}
+
+	if err == nil {
+		t.Fatalf("expected error to be not nil")
+	}
+}
+
+func TestAuthCookieManager_SetStateCookie(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	mockLogger := NewMockLoggerInterface(ctrl)
+	mockEncrypt := NewMockEncryptInterface(ctrl)
+
+	state := FlowStateCookie{}
+	js, _ := json.Marshal(state)
+
+	mockEncrypt.EXPECT().Encrypt(string(js)).Return("mock-state", nil)
+
+	mockResponse := httptest.NewRecorder()
+
+	manager := NewAuthCookieManager(5, mockEncrypt, mockLogger)
+	err := manager.SetStateCookie(mockResponse, state)
+
+	c, found := findCookie("login_ui_state", mockResponse.Result().Cookies())
+
+	if !found {
+		t.Fatal("did not set state cookie")
+	}
+
+	if c.Value != "mock-state" {
+		t.Fatal("state cookie value does not match expected")
+	}
+
+	if err != nil {
+		t.Fatalf("expected error to be nil not  %v", err)
+	}
+}
+
+func TestAuthCookieManager_SetStateCookieFailure(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	mockError := errors.New("mock-error")
+	state := FlowStateCookie{}
+	js, _ := json.Marshal(state)
+
+	mockLogger := NewMockLoggerInterface(ctrl)
+	mockLogger.EXPECT().Errorf("can't encrypt cookie value, %v", mockError).Times(1)
+
+	mockEncrypt := NewMockEncryptInterface(ctrl)
+	mockEncrypt.EXPECT().Encrypt(string(js)).Return("", mockError)
+
+	mockResponse := httptest.NewRecorder()
+
+	manager := NewAuthCookieManager(5, mockEncrypt, mockLogger)
+	err := manager.SetStateCookie(mockResponse, state)
+
+	if err == nil {
+		t.Fatalf("expected error to be not nil")
+	}
+}

--- a/pkg/kratos/encryption.go
+++ b/pkg/kratos/encryption.go
@@ -1,0 +1,101 @@
+// Copyright 2024 Canonical Ltd.
+// SPDX-License-Identifier: AGPL-3.0
+
+package kratos
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"io"
+
+	"github.com/canonical/identity-platform-login-ui/internal/logging"
+	"github.com/canonical/identity-platform-login-ui/internal/tracing"
+)
+
+// needed for testing purposes
+var ioReadFull = io.ReadFull
+
+type Encrypt struct {
+	gcm cipher.AEAD
+
+	logger logging.LoggerInterface
+	tracer tracing.TracingInterface
+}
+
+// Encrypt takes a plain string and returns a hex encoded string
+func (e *Encrypt) Encrypt(data string) (string, error) {
+	payload := []byte(data)
+	nonce, err := e.generateCipherNonce()
+	if err != nil {
+		err = fmt.Errorf("error generating random the nonce, %v", err)
+		e.logger.Error(err.Error())
+		return "", err
+	}
+	ciphertext := e.gcm.Seal(nonce, nonce, payload, nil)
+	return hex.EncodeToString(ciphertext), nil
+}
+
+// Decrypt takes hex encoded string and returns the decrypted plain string
+func (e *Encrypt) Decrypt(hexData string) (string, error) {
+	encrypted, err := hex.DecodeString(hexData)
+	if err != nil {
+		err = fmt.Errorf("error decoding hex encoded string, %v", err)
+		e.logger.Error(err.Error())
+		return "", err
+	}
+
+	noncePart, payloadPart, err := e.splitNonceFromPayload(encrypted)
+	if err != nil {
+		e.logger.Error(err.Error())
+		return "", err
+	}
+
+	decryptedData, err := e.gcm.Open(nil, noncePart, payloadPart, nil)
+	if err != nil {
+		err = fmt.Errorf("error decrypting data: %v", err)
+		e.logger.Error(err.Error())
+		return "", err
+	}
+
+	return string(decryptedData), nil
+}
+
+func (e *Encrypt) splitNonceFromPayload(encrypted []byte) ([]byte, []byte, error) {
+	nonceSize := e.gcm.NonceSize()
+	if len(encrypted) <= nonceSize {
+		return nil, nil, fmt.Errorf("encrypted data malformed")
+	}
+
+	noncePart, payloadPart := encrypted[:nonceSize], encrypted[nonceSize:]
+	return noncePart, payloadPart, nil
+}
+
+func (e *Encrypt) generateCipherNonce() ([]byte, error) {
+	nonce := make([]byte, e.gcm.NonceSize())
+	if _, err := ioReadFull(rand.Reader, nonce); err != nil {
+		return nil, err
+	}
+
+	return nonce, nil
+}
+
+func NewEncrypt(secretKey []byte, logger logging.LoggerInterface, tracer tracing.TracingInterface) *Encrypt {
+	e := new(Encrypt)
+	c, err := aes.NewCipher(secretKey)
+	if err != nil {
+		logger.Fatalf("fatal error creating cipher from secret key, %v", err)
+	}
+
+	gcm, err := cipher.NewGCM(c)
+	if err != nil {
+		logger.Fatalf("fatal error creating gcm from cipher, %v", err)
+	}
+	e.gcm = gcm
+
+	e.logger = logger
+	e.tracer = tracer
+	return e
+}

--- a/pkg/kratos/encryption_test.go
+++ b/pkg/kratos/encryption_test.go
@@ -1,0 +1,161 @@
+// Copyright 2024 Canonical Ltd.
+// SPDX-License-Identifier: AGPL-3.0
+
+package kratos
+
+import (
+	"encoding/hex"
+	"errors"
+	"io"
+	"testing"
+
+	"go.uber.org/mock/gomock"
+)
+
+//go:generate mockgen -build_flags=--mod=mod -package kratos -destination ./mock_logger.go -source=../../internal/logging/interfaces.go
+//go:generate mockgen -build_flags=--mod=mod -package kratos -destination ./mock_cipher.go crypto/cipher AEAD
+//go:generate mockgen -build_flags=--mod=mod -package kratos -destination ./mock_tracing.go go.opentelemetry.io/otel/trace Tracer
+
+const (
+	mockSecretKey       = "caskjdflasjkfdlaksjfalskdfjasfda"
+	mockStringEncrypted = "b44c81a3577085a44105f90902da59a882d5f94f436a5da27ac7c26d7df87cd553d24f845ee4ac"
+	mockStringPlain     = "mock-string"
+)
+
+func TestEncrypt_Decrypt(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	tests := []struct {
+		name           string
+		hexData        string
+		setupMocks     func(*Encrypt, *MockLoggerInterface)
+		expected       string
+		expectedErrMsg string
+	}{
+		{
+			name:           "Success",
+			hexData:        mockStringEncrypted,
+			expected:       mockStringPlain,
+			setupMocks:     func(e *Encrypt, logger *MockLoggerInterface) {},
+			expectedErrMsg: "",
+		},
+		{
+			name:     "FailureDecodeHex",
+			hexData:  "not-hex-encoded-string",
+			expected: "",
+			setupMocks: func(e *Encrypt, logger *MockLoggerInterface) {
+				logger.EXPECT().Error("error decoding hex encoded string, encoding/hex: invalid byte: U+006E 'n'")
+			},
+			expectedErrMsg: "error decoding hex encoded string, encoding/hex: invalid byte: U+006E 'n'",
+		},
+		{
+			name:    "FailureDecodedHexTooShort",
+			hexData: hex.EncodeToString([]byte("short")),
+			setupMocks: func(encrypt *Encrypt, logger *MockLoggerInterface) {
+				logger.EXPECT().Error("encrypted data malformed")
+			},
+			expectedErrMsg: "encrypted data malformed",
+		},
+		{
+			name:     "FailureDecryption",
+			hexData:  mockStringEncrypted,
+			expected: "",
+			setupMocks: func(e *Encrypt, logger *MockLoggerInterface) {
+				logger.EXPECT().Error("error decrypting data: mock-error")
+
+				mockGcm := NewMockAEAD(ctrl)
+				mockGcm.EXPECT().Open(nil, gomock.Any(), gomock.Any(), nil).
+					Times(1).Return(nil, errors.New("mock-error"))
+				mockGcm.EXPECT().NonceSize().Times(1).Return(12)
+				e.gcm = mockGcm
+			},
+			expectedErrMsg: "error decrypting data: mock-error",
+		},
+	}
+
+	for _, tt := range tests {
+		test := tt
+		t.Run(test.name, func(t *testing.T) {
+			logger := NewMockLoggerInterface(ctrl)
+			tracer := NewMockTracingInterface(ctrl)
+			e := NewEncrypt([]byte(mockSecretKey), logger, tracer)
+
+			tt.setupMocks(e, logger)
+
+			got, err := e.Decrypt(tt.hexData)
+
+			if (err != nil) && err.Error() != tt.expectedErrMsg {
+				t.Errorf("Decrypt() error = %v, expected %v", err, tt.expectedErrMsg)
+				return
+			}
+
+			if tt.expected != "" && got != tt.expected {
+				t.Errorf("Decrypt() got = %v, expected %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestEncrypt_Encrypt(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	tests := []struct {
+		name           string
+		plainData      string
+		setupMocks     func(*MockLoggerInterface)
+		expected       string
+		expectedErrMsg string
+	}{
+		{
+			name:      "Success",
+			plainData: mockStringPlain,
+			expected:  "616161616161616161616161923066289ca92b14015213279526f358a73fd718956ea8eea85c2d",
+			setupMocks: func(logger *MockLoggerInterface) {
+				ioReadFull = func(r io.Reader, buf []byte) (n int, err error) {
+					copy(buf, "aaaaaaaaaaaa")
+					return 12, nil
+				}
+			},
+			expectedErrMsg: "",
+		},
+		{
+			name:      "FailureNonceGeneration",
+			plainData: mockStringPlain,
+			expected:  "",
+			setupMocks: func(logger *MockLoggerInterface) {
+				ioReadFull = func(r io.Reader, buf []byte) (n int, err error) {
+					return 0, errors.New("mock-error")
+				}
+				logger.EXPECT().Error("error generating random the nonce, mock-error")
+			},
+			expectedErrMsg: "error generating random the nonce, mock-error",
+		},
+	}
+
+	for _, tt := range tests {
+		test := tt
+		t.Run(test.name, func(t *testing.T) {
+			defer func() {
+				// put things back in order
+				ioReadFull = io.ReadFull
+			}()
+
+			logger := NewMockLoggerInterface(ctrl)
+			tracer := NewMockTracingInterface(ctrl)
+			e := NewEncrypt([]byte(mockSecretKey), logger, tracer)
+
+			tt.setupMocks(logger)
+
+			got, err := e.Encrypt(tt.plainData)
+
+			if (err != nil) && err.Error() != tt.expectedErrMsg {
+				t.Errorf("Encrypt() error = %v, expected %v", err, tt.expectedErrMsg)
+				return
+			}
+
+			if tt.expected != "" && got != tt.expected {
+				t.Errorf("Encrypt() got = %v, expected %v", got, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/kratos/handlers.go
+++ b/pkg/kratos/handlers.go
@@ -94,6 +94,14 @@ func (a *API) handleCreateFlow(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
+	}
+
+	forceLogin, err := a.service.MustReAuthenticate(r.Context(), loginChallenge, session)
+	if err != nil {
+		a.logger.Errorf("Failed to fetch hydra flow: %v", err)
+		http.Error(w, "Failed to fetch hydra flow", http.StatusInternalServerError)
+	}
+	if !forceLogin {
 		response, cookies, err = a.handleCreateFlowWithSession(r, session, loginChallenge)
 	} else {
 		response, cookies, err = a.handleCreateFlowNewSession(r, aal, returnTo, loginChallenge, refresh)

--- a/pkg/kratos/handlers.go
+++ b/pkg/kratos/handlers.go
@@ -2,6 +2,8 @@ package kratos
 
 import (
 	"context"
+	"crypto/md5"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -18,12 +20,14 @@ import (
 
 const RegenerateBackupCodesError = "regenerate_backup_codes"
 const KRATOS_SESSION_COOKIE_NAME = "ory_kratos_session"
+const LOGIN_UI_STATE_COOKIE = "login_ui_state"
 
 type API struct {
-	mfaEnabled  bool
-	service     ServiceInterface
-	baseURL     string
-	contextPath string
+	mfaEnabled    bool
+	service       ServiceInterface
+	baseURL       string
+	contextPath   string
+	cookieManager AuthCookieManagerInterface
 
 	logger logging.LoggerInterface
 }
@@ -88,18 +92,25 @@ func (a *API) handleCreateFlow(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			a.logger.Errorf("Failed check for MFA: %v", err)
 			http.Error(w, "Failed check for MFA", http.StatusInternalServerError)
-		}
-		if shouldEnforceMfa {
-			a.mfaSettingsRedirect(w, returnTo)
 			return
 		}
-
+		if shouldEnforceMfa {
+			a.mfaSettingsRedirect(w, returnTo, loginChallenge)
+			return
+		}
 	}
 
-	forceLogin, err := a.service.MustReAuthenticate(r.Context(), loginChallenge, session)
+	c, err := a.cookieManager.GetStateCookie(r)
+	if err != nil {
+		a.logger.Errorf("Failed to parse state cookie: %v", err)
+		http.Error(w, "Failed to parse state cookie", http.StatusInternalServerError)
+		return
+	}
+	forceLogin, err := a.service.MustReAuthenticate(r.Context(), loginChallenge, session, c)
 	if err != nil {
 		a.logger.Errorf("Failed to fetch hydra flow: %v", err)
 		http.Error(w, "Failed to fetch hydra flow", http.StatusInternalServerError)
+		return
 	}
 	if !forceLogin {
 		response, cookies, err = a.handleCreateFlowWithSession(r, session, loginChallenge)
@@ -251,7 +262,7 @@ func (a *API) handleUpdateFlow(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if shouldEnforceMfa {
-		a.mfaSettingsRedirect(w, *loginFlow.ReturnTo)
+		a.mfaSettingsRedirect(w, *loginFlow.ReturnTo, loginFlow.GetOauth2LoginChallenge())
 		return
 	}
 
@@ -346,7 +357,9 @@ func (a *API) is40xError(err error) bool {
 	return false
 }
 
-func (a *API) mfaSettingsRedirect(w http.ResponseWriter, returnTo string) {
+func (a *API) mfaSettingsRedirect(w http.ResponseWriter, returnTo, loginChallenge string) {
+	var sessionId string
+
 	redirect, err := url.JoinPath("/", a.contextPath, "/ui/setup_secure")
 
 	if err != nil {
@@ -358,10 +371,14 @@ func (a *API) mfaSettingsRedirect(w http.ResponseWriter, returnTo string) {
 
 	errorId := "session_aal2_required"
 
+	if loginChallenge != "" {
+		sessionId = hash(loginChallenge)
+	}
 	// Set the original login URL as return_to, to continue the flow after mfa
 	// has been set.
 	r, _ := addParamsToURL(redirect, queryParam{"return_to", returnTo})
 
+	a.cookieManager.SetStateCookie(w, FlowStateCookie{LoginChallengeHash: sessionId, TotpSetup: true})
 	w.WriteHeader(http.StatusSeeOther)
 	_ = json.NewEncoder(w).Encode(
 		ErrorBrowserLocationChangeRequired{
@@ -631,12 +648,18 @@ func addParamsToURL(u string, qs ...queryParam) (string, error) {
 	return uu.String(), nil
 }
 
-func NewAPI(service ServiceInterface, mfaEnabled bool, baseURL string, logger logging.LoggerInterface) *API {
+func NewAPI(
+	service ServiceInterface,
+	mfaEnabled bool,
+	baseURL string,
+	cookieManager AuthCookieManagerInterface,
+	logger logging.LoggerInterface) *API {
 	a := new(API)
 
 	a.mfaEnabled = mfaEnabled
 	a.service = service
 	a.baseURL = baseURL
+	a.cookieManager = cookieManager
 
 	fullBaseURL, err := url.Parse(baseURL)
 	if err != nil {
@@ -669,4 +692,16 @@ l1:
 		ret = append(ret, c)
 	}
 	return ret
+}
+
+func hash(plain string) string {
+	h := md5.New()
+	h.Write([]byte(plain))
+	return base64.URLEncoding.EncodeToString(h.Sum(nil))
+}
+
+func validateHash(plain, sig string) bool {
+	h := md5.New()
+	h.Write([]byte(plain))
+	return base64.URLEncoding.EncodeToString(h.Sum(nil)) == sig
 }

--- a/pkg/kratos/handlers.go
+++ b/pkg/kratos/handlers.go
@@ -153,7 +153,7 @@ func (a *API) handleCreateFlowNewSession(r *http.Request, aal string, returnTo s
 }
 
 func (a *API) handleCreateFlowWithSession(r *http.Request, session *client.Session, loginChallenge string) (any, []*http.Cookie, error) {
-	response, cookies, err := a.service.AcceptLoginRequest(r.Context(), session.Identity.Id, loginChallenge)
+	response, cookies, err := a.service.AcceptLoginRequest(r.Context(), session, loginChallenge)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to accept login request: %v", err)
 	}

--- a/pkg/kratos/handlers_test.go
+++ b/pkg/kratos/handlers_test.go
@@ -81,6 +81,7 @@ func TestHandleCreateFlowWithoutSession(t *testing.T) {
 	req.URL.RawQuery = values.Encode()
 
 	mockService.EXPECT().CheckSession(gomock.Any(), req.Cookies()).Return(nil, nil, nil)
+	mockService.EXPECT().MustReAuthenticate(gomock.Any(), loginChallenge, nil).Return(true, nil)
 	mockService.EXPECT().CreateBrowserLoginFlow(gomock.Any(), gomock.Any(), returnTo, loginChallenge, gomock.Any(), req.Cookies()).Return(flow, req.Cookies(), nil)
 	mockService.EXPECT().FilterFlowProviderList(gomock.Any(), flow).Return(flow, nil)
 
@@ -131,6 +132,7 @@ func TestHandleCreateFlowWithoutSessionFailOnCreateBrowserLoginFlow(t *testing.T
 
 	mockLogger.EXPECT().Errorf("failed to create login flow, err: error")
 	mockService.EXPECT().CheckSession(gomock.Any(), req.Cookies()).Return(nil, nil, nil)
+	mockService.EXPECT().MustReAuthenticate(gomock.Any(), loginChallenge, nil).Return(true, nil)
 	mockService.EXPECT().CreateBrowserLoginFlow(gomock.Any(), gomock.Any(), returnTo, loginChallenge, gomock.Any(), req.Cookies()).Return(nil, nil, fmt.Errorf("error"))
 
 	w := httptest.NewRecorder()
@@ -167,6 +169,7 @@ func TestHandleCreateFlowWithoutSessionFailOnFilterProviders(t *testing.T) {
 	req.URL.RawQuery = values.Encode()
 
 	mockService.EXPECT().CheckSession(gomock.Any(), req.Cookies()).Return(nil, nil, nil)
+	mockService.EXPECT().MustReAuthenticate(gomock.Any(), loginChallenge, nil).Return(true, nil)
 	mockService.EXPECT().CreateBrowserLoginFlow(gomock.Any(), gomock.Any(), returnTo, loginChallenge, gomock.Any(), req.Cookies()).Return(flow, req.Cookies(), nil)
 	mockService.EXPECT().FilterFlowProviderList(gomock.Any(), flow).Return(nil, fmt.Errorf("oh no"))
 	mockLogger.EXPECT().Errorf(gomock.Any(), gomock.Any()).Times(1)
@@ -205,6 +208,7 @@ func TestHandleCreateFlowWithoutSessionWhenNoProvidersAllowed(t *testing.T) {
 	req.URL.RawQuery = values.Encode()
 
 	mockService.EXPECT().CheckSession(gomock.Any(), req.Cookies()).Return(nil, nil, nil)
+	mockService.EXPECT().MustReAuthenticate(gomock.Any(), loginChallenge, nil).Return(true, nil)
 	mockService.EXPECT().CreateBrowserLoginFlow(gomock.Any(), gomock.Any(), returnTo, loginChallenge, gomock.Any(), req.Cookies()).Return(flow, req.Cookies(), nil)
 	mockService.EXPECT().FilterFlowProviderList(gomock.Any(), flow).Return(flow, nil)
 
@@ -253,6 +257,7 @@ func TestHandleCreateFlowWithSession(t *testing.T) {
 	req.URL.RawQuery = values.Encode()
 
 	mockService.EXPECT().CheckSession(gomock.Any(), req.Cookies()).Return(session, nil, nil)
+	mockService.EXPECT().MustReAuthenticate(gomock.Any(), loginChallenge, session).Return(false, nil)
 	mockService.EXPECT().AcceptLoginRequest(gomock.Any(), "test", loginChallenge).Return(redirectTo, req.Cookies(), nil)
 
 	w := httptest.NewRecorder()
@@ -295,6 +300,7 @@ func TestHandleCreateFlowWithSessionFailOnAcceptLoginRequest(t *testing.T) {
 	req.URL.RawQuery = values.Encode()
 
 	mockService.EXPECT().CheckSession(gomock.Any(), req.Cookies()).Return(session, nil, nil)
+	mockService.EXPECT().MustReAuthenticate(gomock.Any(), loginChallenge, session).Return(false, nil)
 	mockService.EXPECT().AcceptLoginRequest(gomock.Any(), "test", loginChallenge).Return(nil, nil, fmt.Errorf("error"))
 	mockLogger.EXPECT().Errorf(gomock.Any(), gomock.Any()).Times(1)
 

--- a/pkg/kratos/handlers_test.go
+++ b/pkg/kratos/handlers_test.go
@@ -268,7 +268,7 @@ func TestHandleCreateFlowWithSession(t *testing.T) {
 
 	mockService.EXPECT().CheckSession(gomock.Any(), req.Cookies()).Return(session, nil, nil)
 	mockService.EXPECT().MustReAuthenticate(gomock.Any(), loginChallenge, session, FlowStateCookie{}).Return(false, nil)
-	mockService.EXPECT().AcceptLoginRequest(gomock.Any(), "test", loginChallenge).Return(redirectTo, req.Cookies(), nil)
+	mockService.EXPECT().AcceptLoginRequest(gomock.Any(), session, loginChallenge).Return(redirectTo, req.Cookies(), nil)
 	mockCookieManager.EXPECT().GetStateCookie(gomock.Any()).Return(FlowStateCookie{}, nil)
 
 	w := httptest.NewRecorder()
@@ -314,7 +314,7 @@ func TestHandleCreateFlowWithSessionFailOnAcceptLoginRequest(t *testing.T) {
 
 	mockService.EXPECT().CheckSession(gomock.Any(), req.Cookies()).Return(session, nil, nil)
 	mockService.EXPECT().MustReAuthenticate(gomock.Any(), loginChallenge, session, FlowStateCookie{}).Return(false, nil)
-	mockService.EXPECT().AcceptLoginRequest(gomock.Any(), "test", loginChallenge).Return(nil, nil, fmt.Errorf("error"))
+	mockService.EXPECT().AcceptLoginRequest(gomock.Any(), session, loginChallenge).Return(nil, nil, fmt.Errorf("error"))
 	mockCookieManager.EXPECT().GetStateCookie(gomock.Any()).Return(FlowStateCookie{}, nil)
 	mockLogger.EXPECT().Errorf(gomock.Any(), gomock.Any()).Times(1)
 

--- a/pkg/kratos/interfaces.go
+++ b/pkg/kratos/interfaces.go
@@ -29,7 +29,7 @@ type AuthorizerInterface interface {
 type ServiceInterface interface {
 	CheckSession(context.Context, []*http.Cookie) (*kClient.Session, []*http.Cookie, error)
 	AcceptLoginRequest(context.Context, string, string) (*hClient.OAuth2RedirectTo, []*http.Cookie, error)
-	MustReAuthenticate(context.Context, string, *kClient.Session) (bool, error)
+	MustReAuthenticate(context.Context, string, *kClient.Session, FlowStateCookie) (bool, error)
 	CreateBrowserLoginFlow(context.Context, string, string, string, bool, []*http.Cookie) (*kClient.LoginFlow, []*http.Cookie, error)
 	CreateBrowserRecoveryFlow(context.Context, string, []*http.Cookie) (*kClient.RecoveryFlow, []*http.Cookie, error)
 	CreateBrowserSettingsFlow(context.Context, string, []*http.Cookie) (*kClient.SettingsFlow, *BrowserLocationChangeRequired, error)
@@ -47,4 +47,20 @@ type ServiceInterface interface {
 	ParseSettingsFlowMethodBody(*http.Request) (*kClient.UpdateSettingsFlowBody, error)
 	HasTOTPAvailable(context.Context, string) (bool, error)
 	HasNotEnoughLookupSecretsLeft(context.Context, string) (bool, error)
+}
+
+type AuthCookieManagerInterface interface {
+	// SetStateCookie sets the nonce cookie on the response with the specified duration as MaxAge
+	SetStateCookie(http.ResponseWriter, FlowStateCookie) error
+	// GetStateCookie returns the string value of the nonce cookie if present, or empty string otherwise
+	GetStateCookie(*http.Request) (FlowStateCookie, error)
+	// ClearStateCookie sets the expiration of the cookie to epoch
+	ClearStateCookie(http.ResponseWriter)
+}
+
+type EncryptInterface interface {
+	// Encrypt a plain text string, returns the encrypted string in hex format or an error
+	Encrypt(string) (string, error)
+	// Decrypt a hex string, returns the decrypted string or an error
+	Decrypt(string) (string, error)
 }

--- a/pkg/kratos/interfaces.go
+++ b/pkg/kratos/interfaces.go
@@ -28,7 +28,7 @@ type AuthorizerInterface interface {
 
 type ServiceInterface interface {
 	CheckSession(context.Context, []*http.Cookie) (*kClient.Session, []*http.Cookie, error)
-	AcceptLoginRequest(context.Context, string, string) (*hClient.OAuth2RedirectTo, []*http.Cookie, error)
+	AcceptLoginRequest(context.Context, *kClient.Session, string) (*hClient.OAuth2RedirectTo, []*http.Cookie, error)
 	MustReAuthenticate(context.Context, string, *kClient.Session, FlowStateCookie) (bool, error)
 	CreateBrowserLoginFlow(context.Context, string, string, string, bool, []*http.Cookie) (*kClient.LoginFlow, []*http.Cookie, error)
 	CreateBrowserRecoveryFlow(context.Context, string, []*http.Cookie) (*kClient.RecoveryFlow, []*http.Cookie, error)

--- a/pkg/kratos/interfaces.go
+++ b/pkg/kratos/interfaces.go
@@ -29,6 +29,7 @@ type AuthorizerInterface interface {
 type ServiceInterface interface {
 	CheckSession(context.Context, []*http.Cookie) (*kClient.Session, []*http.Cookie, error)
 	AcceptLoginRequest(context.Context, string, string) (*hClient.OAuth2RedirectTo, []*http.Cookie, error)
+	MustReAuthenticate(context.Context, string, *kClient.Session) (bool, error)
 	CreateBrowserLoginFlow(context.Context, string, string, string, bool, []*http.Cookie) (*kClient.LoginFlow, []*http.Cookie, error)
 	CreateBrowserRecoveryFlow(context.Context, string, []*http.Cookie) (*kClient.RecoveryFlow, []*http.Cookie, error)
 	CreateBrowserSettingsFlow(context.Context, string, []*http.Cookie) (*kClient.SettingsFlow, *BrowserLocationChangeRequired, error)

--- a/pkg/web/router.go
+++ b/pkg/web/router.go
@@ -22,7 +22,19 @@ import (
 	"github.com/canonical/identity-platform-login-ui/pkg/ui"
 )
 
-func NewRouter(kratosClient *ik.Client, kratosAdminClient *ik.Client, hydraClient *ih.Client, authzClient authz.AuthorizerInterface, distFS fs.FS, mfaEnabled bool, baseURL string, tracer tracing.TracingInterface, monitor monitoring.MonitorInterface, logger logging.LoggerInterface) http.Handler {
+func NewRouter(
+	kratosClient *ik.Client,
+	kratosAdminClient *ik.Client,
+	hydraClient *ih.Client,
+	authzClient authz.AuthorizerInterface,
+	cookieManager *kratos.AuthCookieManager,
+	distFS fs.FS,
+	mfaEnabled bool,
+	baseURL string,
+	tracer tracing.TracingInterface,
+	monitor monitoring.MonitorInterface,
+	logger logging.LoggerInterface,
+) http.Handler {
 	router := chi.NewMux()
 
 	middlewares := make(chi.Middlewares, 0)
@@ -52,6 +64,7 @@ func NewRouter(kratosClient *ik.Client, kratosAdminClient *ik.Client, hydraClien
 		kratosService,
 		mfaEnabled,
 		baseURL,
+		cookieManager,
 		logger,
 	).RegisterEndpoints(router)
 	extra.NewAPI(extra.NewService(hydraClient, tracer, monitor, logger), kratosService, logger).RegisterEndpoints(router)


### PR DESCRIPTION
IAM-1127

Fetch the hydra login request and check the `Skip` value to decide whether we should accept it if a session exists. Otherwise (if this isn't a hydra flow or if there is no session) we leave it to Kratos. This fixes the issue where `max_age` was not respected.

Closes #300 