### PR TITLE
fix: do not enforce re-authentication when user was offered to regenerate backup codes

### DIFF
--- a/pkg/kratos/cookies.go
+++ b/pkg/kratos/cookies.go
@@ -30,6 +30,7 @@ type AuthCookieManager struct {
 type FlowStateCookie struct {
 	LoginChallengeHash string `json:"lc,omitempty"`
 	TotpSetup          bool   `json:"t,omitempty"`
+	BackupCodeUsed     bool   `json:"bc,omitempty"`
 }
 
 func (a *AuthCookieManager) SetStateCookie(w http.ResponseWriter, state FlowStateCookie) error {

--- a/pkg/kratos/handlers_test.go
+++ b/pkg/kratos/handlers_test.go
@@ -586,6 +586,7 @@ func TestHandleUpdateLoginFlowRedirectToRegenerateBackupCodes(t *testing.T) {
 
 	mockService.EXPECT().CheckSession(gomock.Any(), req.Cookies()).Return(session, nil, nil)
 	mockService.EXPECT().HasNotEnoughLookupSecretsLeft(gomock.Any(), session.Identity.GetId()).Return(true, nil)
+	mockCookieManager.EXPECT().SetStateCookie(gomock.Any(), gomock.Any()).Return(nil)
 
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()

--- a/pkg/kratos/service.go
+++ b/pkg/kratos/service.go
@@ -151,8 +151,9 @@ func (s *Service) MustReAuthenticate(ctx context.Context, hydraLoginChallenge st
 		return true, nil
 	}
 
-	// This is the first user login, they set up their authenticator app, no need to re-auth
-	if validateHash(hydraLoginChallenge, c.LoginChallengeHash) && c.TotpSetup {
+	// This is the first user login, they set up their authenticator app
+	// Or backup code was used for login, no need to re-auth
+	if validateHash(hydraLoginChallenge, c.LoginChallengeHash) && (c.TotpSetup || c.BackupCodeUsed) {
 		return false, nil
 	}
 


### PR DESCRIPTION
fixes https://github.com/canonical/identity-platform-login-ui/issues/371