### PR TITLE
Support OIDC and WebAuthn sequencing for aal2

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -93,7 +93,7 @@ func serve() {
 		panic("Invalid authorization model provided")
 	}
 
-	router := web.NewRouter(kClient, kAdminClient, hClient, authorizer, cookieManager, distFS, specs.MFAEnabled, specs.BaseURL, tracer, monitor, logger)
+	router := web.NewRouter(kClient, kAdminClient, hClient, authorizer, cookieManager, distFS, specs.MFAEnabled, specs.OIDCWebAuthnSequencingEnabled, specs.BaseURL, tracer, monitor, logger)
 
 	logger.Infof("Starting server on port %v", specs.Port)
 

--- a/docs/sequencing.md
+++ b/docs/sequencing.md
@@ -1,0 +1,68 @@
+## OIDC-WebAuthn Sequencing
+
+This application exposes an `OIDC_WEBAUTHN_SEQUENCING_ENABLED` environment variable, which defaults to `false`.
+
+**Do not enable this option unless you are sure that this feature applies to your deployment.**
+
+If set to `true`, Login UI will enforce setting up a WebAuthn key (e.g. with YubiKey or Google Password Manager on Android) right after signing in with an external identity provider (Google, GitHub, Entra ID, ...), given that the user has not done it previously.
+Users will be asked to complete it as the second authentication factor on every login flow, regardless of the authentication controls enforced by the identity provider.
+
+Enabling this option works on the assumption that your Kratos config has the `passwordless` flag set to `false`:
+
+```yaml
+selfservice:
+  methods:
+    webauthn:
+      enabled: True
+      config:
+        passwordless: false
+```
+
+This is currently not supported in the Kratos Charmed Operator.
+
+### Testing
+
+In order to test this feature:
+
+1. Switch the aforementioned flag to `false` and disable the `totp` and `password` methods in the [kratos](https://github.com/canonical/identity-platform-login-ui/blob/main/docker/kratos/kratos.yml) configuration for Docker.
+
+2. Set environment variables:
+
+    ```bash
+    export OIDC_WEBAUTHN_SEQUENCING_ENABLED="true"
+    ```
+
+3. Follow the [instructions](https://github.com/canonical/identity-platform-login-ui/blob/main/README.md#try-it-out) to integrate an external identity provider and run the docker setup.
+
+4. Create a hydra client for an application you'll use to test the login flow. Save the client id and secret.
+
+    ```docker
+    docker exec <hydra-container> \
+    hydra create client \
+        --endpoint http://127.0.0.1:4445 \
+        --name <app-name> \
+        --grant-type authorization_code,refresh_token \
+        --response-type code,id_token \
+        --format json \
+        --scope openid,offline_access,email \
+        --redirect-uri <app-redirect-uri>
+    ```
+
+5. Deploy an application that supports OIDC. We'll use Grafana as an example:
+
+    ```docker
+    docker run -d --name=grafana -p 2345:2345 --network identity-platform-login-ui_intranet \
+    -e "GF_SERVER_HTTP_PORT=2345" \
+    -e "GF_AUTH_GENERIC_OAUTH_ENABLED=true" \
+    -e "GF_AUTH_GENERIC_OAUTH_AUTH_ALLOWED_DOMAINS=hydra,localhost" \
+    -e "GF_AUTH_GENERIC_OAUTH_NAME=Identity Platform" \
+    -e "GF_AUTH_GENERIC_OAUTH_CLIENT_ID=<client-id>" \
+    -e "GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET=<client-secret>" \
+    -e "GF_AUTH_GENERIC_OAUTH_SCOPES=openid offline_access email" \
+    -e "GF_AUTH_GENERIC_OAUTH_AUTH_URL=http://localhost:4444/oauth2/auth" \
+    -e "GF_AUTH_GENERIC_OAUTH_TOKEN_URL=http://hydra:4444/oauth2/token" \
+    -e "GF_AUTH_GENERIC_OAUTH_API_URL=http://hydra:4444/userinfo" \
+    grafana/grafana
+    ```
+
+6. Go to the application's login page and click on `Sign in with Identity Platform`. Then, sign in with the integrated identity provider. Upon a successful authentication, you will be asked to create a WebAuthn key.

--- a/internal/config/specs.go
+++ b/internal/config/specs.go
@@ -28,7 +28,8 @@ type EnvSpec struct {
 	AuthorizationModelId string `envconfig:"openfga_authorization_model_id" default:""`
 	AuthorizationEnabled bool   `envconfig:"authorization_enabled" default:"false"`
 
-	MFAEnabled bool `envconfig:"mfa_enabled" default:"true"`
+	MFAEnabled                    bool `envconfig:"mfa_enabled" default:"true"`
+	OIDCWebAuthnSequencingEnabled bool `envconfig:"oidc_webauthn_sequencing_enabled" default:"false"`
 }
 
 type Flags struct {

--- a/pkg/extra/handlers.go
+++ b/pkg/extra/handlers.go
@@ -11,7 +11,6 @@ import (
 	client "github.com/ory/kratos-client-go"
 
 	"github.com/canonical/identity-platform-login-ui/internal/logging"
-	httpHelpers "github.com/canonical/identity-platform-login-ui/internal/misc/http"
 	"github.com/canonical/identity-platform-login-ui/pkg/kratos"
 )
 
@@ -19,10 +18,10 @@ type API struct {
 	service ServiceInterface
 	kratos  kratos.ServiceInterface
 
-	logger                        logging.LoggerInterface
 	baseURL                       string
 	oidcWebAuthnSequencingEnabled bool
 	contextPath                   string
+	logger                        logging.LoggerInterface
 }
 
 func (a *API) RegisterEndpoints(mux *chi.Mux) {
@@ -42,6 +41,12 @@ func (a *API) handleConsent(w http.ResponseWriter, r *http.Request) {
 	}
 
 	consentChallenge := r.URL.Query().Get("consent_challenge")
+	if consentChallenge == "" {
+		err = fmt.Errorf("no consent challenge present")
+		a.logger.Errorf(err.Error())
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
 
 	if a.oidcWebAuthnSequencingEnabled {
 		// enforce webauthn setup
@@ -55,9 +60,28 @@ func (a *API) handleConsent(w http.ResponseWriter, r *http.Request) {
 
 		if shouldEnforceWebAuthn {
 			returnTo, _ := url.JoinPath("/", a.contextPath, "/ui/consent")
-			returnToConsent, _ := httpHelpers.AddParamsToURL(returnTo, httpHelpers.QueryParam{Name: "consent_challenge", Value: consentChallenge})
-			a.webAuthnSettingsRedirect(w, returnToConsent)
+			returnToConsent, err := url.ParseRequestURI(returnTo)
+			if err != nil {
+				return
+			}
+
+			q := returnToConsent.Query()
+			q.Set("consent_challenge", consentChallenge)
+			returnToConsent.RawQuery = q.Encode()
+			err = a.webAuthnSettingsRedirect(w, returnToConsent.String())
+			if err != nil {
+				err = fmt.Errorf("unable to build webauthn redirect path, possible misconfiguration, err: %v", err)
+				a.logger.Error(err.Error())
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+			}
+
 			return
+		}
+
+		if session.GetAuthenticatorAssuranceLevel() == "aal1" {
+			err = fmt.Errorf("webauthn step was skipped, user has not completed 2fa")
+			a.logger.Error(err.Error())
+			http.Error(w, err.Error(), http.StatusForbidden)
 		}
 	}
 
@@ -93,51 +117,49 @@ func (a *API) handleConsent(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *API) shouldEnforceWebAuthnWithSession(ctx context.Context, session *client.Session) (bool, error) {
-	hasOIDC := false
 	// enforce only if one of the authentication methods was oidc
 	for _, method := range session.AuthenticationMethods {
-		if method.Method != nil && *method.Method == "oidc" {
-			hasOIDC = true
-			break
+		if method.GetMethod() == "oidc" {
+			webAuthnAvailable, err := a.kratos.HasWebAuthnAvailable(ctx, session.Identity.GetId())
+			if err != nil {
+				return false, err
+			}
+			return !webAuthnAvailable, nil
 		}
 	}
-
-	if !hasOIDC {
-		return false, nil
-	}
-
-	webAuthnAvailable, err := a.kratos.HasWebAuthnAvailable(ctx, session.Identity.GetId())
-	if err != nil {
-		return false, err
-	}
-
-	return !webAuthnAvailable, nil
+	return false, nil
 }
 
-func (a *API) webAuthnSettingsRedirect(w http.ResponseWriter, returnTo string) {
+func (a *API) webAuthnSettingsRedirect(w http.ResponseWriter, returnTo string) error {
 	redirect, err := url.JoinPath("/", a.contextPath, "/ui/setup_passkey")
 	if err != nil {
-		err = fmt.Errorf("unable to build webauthn redirect path, possible misconfiguration, err: %v", err)
-		a.logger.Error(err.Error())
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
+		return err
 	}
 
 	errorId := "session_aal2_required"
 
 	// Set the original consent URL as return_to, to continue the flow after WebAuthn key is set
-	redirectTo, _ := httpHelpers.AddParamsToURL(redirect, httpHelpers.QueryParam{Name: "return_to", Value: returnTo})
+	redirectTo, err := url.ParseRequestURI(redirect)
+	if err != nil {
+		return err
+	}
+
+	q := redirectTo.Query()
+	q.Set("return_to", returnTo)
+	redirectTo.RawQuery = q.Encode()
+	redirectPath := redirectTo.String()
 
 	w.WriteHeader(http.StatusSeeOther)
 	_ = json.NewEncoder(w).Encode(
 		kratos.ErrorBrowserLocationChangeRequired{
 			Error:             &client.GenericError{Id: &errorId},
-			RedirectBrowserTo: &redirectTo,
+			RedirectBrowserTo: &redirectPath,
 		},
 	)
+	return nil
 }
 
-func NewAPI(service ServiceInterface, kratos kratos.ServiceInterface, logger logging.LoggerInterface, baseURL string, oidcWebAuthnSequencingEnabled bool) *API {
+func NewAPI(service ServiceInterface, kratos kratos.ServiceInterface, baseURL string, oidcWebAuthnSequencingEnabled bool, logger logging.LoggerInterface) *API {
 	a := new(API)
 
 	a.service = service

--- a/pkg/extra/handlers_test.go
+++ b/pkg/extra/handlers_test.go
@@ -48,7 +48,7 @@ func TestHandleConsentSuccess(t *testing.T) {
 	mockService.EXPECT().AcceptConsent(gomock.Any(), *session.Identity, consent).Return(accept, nil)
 
 	mux := chi.NewMux()
-	NewAPI(mockService, mockKratosService, mockLogger, BASE_URL, false).RegisterEndpoints(mux)
+	NewAPI(mockService, mockKratosService, BASE_URL, false, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -109,7 +109,7 @@ func TestHandleConsentWhenOIDCSequencingEnabled(t *testing.T) {
 	mockService.EXPECT().AcceptConsent(gomock.Any(), *session.Identity, consent).Return(accept, nil)
 
 	mux := chi.NewMux()
-	NewAPI(mockService, mockKratosService, mockLogger, BASE_URL, true).RegisterEndpoints(mux)
+	NewAPI(mockService, mockKratosService, BASE_URL, true, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -162,7 +162,7 @@ func TestHandleConsentFailOnAcceptConsent(t *testing.T) {
 	mockLogger.EXPECT().Errorf(gomock.Any(), gomock.Any()).Times(1)
 
 	mux := chi.NewMux()
-	NewAPI(mockService, mockKratosService, mockLogger, BASE_URL, false).RegisterEndpoints(mux)
+	NewAPI(mockService, mockKratosService, BASE_URL, false, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -197,7 +197,7 @@ func TestHandleConsentFailOnGetConsent(t *testing.T) {
 	mockLogger.EXPECT().Errorf(gomock.Any(), gomock.Any()).Times(1)
 
 	mux := chi.NewMux()
-	NewAPI(mockService, mockKratosService, mockLogger, BASE_URL, false).RegisterEndpoints(mux)
+	NewAPI(mockService, mockKratosService, BASE_URL, false, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -228,7 +228,7 @@ func TestHandleConsentFailOnCheckSession(t *testing.T) {
 	mockLogger.EXPECT().Errorf(gomock.Any(), gomock.Any()).Times(1)
 
 	mux := chi.NewMux()
-	NewAPI(mockService, mockKratosService, mockLogger, BASE_URL, false).RegisterEndpoints(mux)
+	NewAPI(mockService, mockKratosService, BASE_URL, false, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 

--- a/pkg/extra/handlers_test.go
+++ b/pkg/extra/handlers_test.go
@@ -3,7 +3,7 @@ package extra
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -16,6 +16,8 @@ import (
 
 	"github.com/canonical/identity-platform-login-ui/pkg/kratos"
 )
+
+const BASE_URL = "https://example.com"
 
 //go:generate mockgen -build_flags=--mod=mod -package extra -destination ./mock_logger.go -source=../../internal/logging/interfaces.go
 //go:generate mockgen -build_flags=--mod=mod -package extra -destination ./mock_extra.go -source=./interfaces.go
@@ -46,7 +48,7 @@ func TestHandleConsentSuccess(t *testing.T) {
 	mockService.EXPECT().AcceptConsent(gomock.Any(), *session.Identity, consent).Return(accept, nil)
 
 	mux := chi.NewMux()
-	NewAPI(mockService, mockKratosService, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, mockKratosService, mockLogger, BASE_URL, false).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -56,7 +58,68 @@ func TestHandleConsentSuccess(t *testing.T) {
 		t.Fatalf("expected HTTP status code 200 got %v", res.StatusCode)
 	}
 
-	data, err := ioutil.ReadAll(res.Body)
+	data, err := io.ReadAll(res.Body)
+	defer res.Body.Close()
+
+	if err != nil {
+		t.Fatalf("expected error to be nil got %v", err)
+	}
+
+	redirect := hClient.NewOAuth2RedirectToWithDefaults()
+	if err := json.Unmarshal(data, redirect); err != nil {
+		t.Fatalf("expected error to be nil got %v", err)
+	}
+
+	if redirect.RedirectTo != accept.RedirectTo {
+		t.Fatalf("expected %s, got %s.", accept.RedirectTo, redirect.RedirectTo)
+	}
+}
+
+func TestHandleConsentWhenOIDCSequencingEnabled(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := NewMockLoggerInterface(ctrl)
+	mockService := NewMockServiceInterface(ctrl)
+	mockKratosService := kratos.NewMockServiceInterface(ctrl)
+
+	session := kClient.NewSessionWithDefaults()
+	session.SetId("test")
+	session.Identity = kClient.NewIdentity("test", "test.json", "https://test.com/test.json", map[string]string{"name": "name"})
+
+	method := "oidc"
+	var authnMethods []kClient.SessionAuthenticationMethod
+	authnMethods = append(authnMethods, kClient.SessionAuthenticationMethod{Method: &method})
+	session.AuthenticationMethods = authnMethods
+
+	consent := hClient.NewOAuth2ConsentRequest("challenge")
+	accept := hClient.NewOAuth2RedirectTo("test")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/consent", nil)
+
+	values := req.URL.Query()
+	values.Add("consent_challenge", "7bb518c4eec2454dbb289f5fdb4c0ee2")
+	req.URL.RawQuery = values.Encode()
+
+	w := httptest.NewRecorder()
+
+	mockKratosService.EXPECT().CheckSession(gomock.Any(), req.Cookies()).Return(session, nil, nil)
+	mockKratosService.EXPECT().HasWebAuthnAvailable(gomock.Any(), gomock.Any()).Return(true, nil)
+	mockService.EXPECT().GetConsent(gomock.Any(), "7bb518c4eec2454dbb289f5fdb4c0ee2").Return(consent, nil)
+	mockService.EXPECT().AcceptConsent(gomock.Any(), *session.Identity, consent).Return(accept, nil)
+
+	mux := chi.NewMux()
+	NewAPI(mockService, mockKratosService, mockLogger, BASE_URL, true).RegisterEndpoints(mux)
+
+	mux.ServeHTTP(w, req)
+
+	res := w.Result()
+
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("expected HTTP status code 200 got %v", res.StatusCode)
+	}
+
+	data, err := io.ReadAll(res.Body)
 	defer res.Body.Close()
 
 	if err != nil {
@@ -99,7 +162,7 @@ func TestHandleConsentFailOnAcceptConsent(t *testing.T) {
 	mockLogger.EXPECT().Errorf(gomock.Any(), gomock.Any()).Times(1)
 
 	mux := chi.NewMux()
-	NewAPI(mockService, mockKratosService, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, mockKratosService, mockLogger, BASE_URL, false).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -134,7 +197,7 @@ func TestHandleConsentFailOnGetConsent(t *testing.T) {
 	mockLogger.EXPECT().Errorf(gomock.Any(), gomock.Any()).Times(1)
 
 	mux := chi.NewMux()
-	NewAPI(mockService, mockKratosService, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, mockKratosService, mockLogger, BASE_URL, false).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -165,7 +228,7 @@ func TestHandleConsentFailOnCheckSession(t *testing.T) {
 	mockLogger.EXPECT().Errorf(gomock.Any(), gomock.Any()).Times(1)
 
 	mux := chi.NewMux()
-	NewAPI(mockService, mockKratosService, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, mockKratosService, mockLogger, BASE_URL, false).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 

--- a/pkg/kratos/handlers.go
+++ b/pkg/kratos/handlers.go
@@ -86,7 +86,7 @@ func (a *API) handleCreateFlow(w http.ResponseWriter, r *http.Request) {
 	// if the user is logged in, CreateBrowserLoginFlow call will return an empty response
 	// TODO: We need to send a different content-type to CreateBrowserLoginFlow in order to avoid this bug.
 	session, _, _ := a.service.CheckSession(r.Context(), r.Cookies())
-	if session != nil {
+	if session != nil && a.mfaEnabled {
 		shouldEnforceMfa, err = a.shouldEnforceMFAWithSession(r.Context(), session)
 
 		if err != nil {

--- a/pkg/kratos/interfaces.go
+++ b/pkg/kratos/interfaces.go
@@ -46,6 +46,7 @@ type ServiceInterface interface {
 	ParseRecoveryFlowMethodBody(*http.Request) (*kClient.UpdateRecoveryFlowBody, error)
 	ParseSettingsFlowMethodBody(*http.Request) (*kClient.UpdateSettingsFlowBody, error)
 	HasTOTPAvailable(context.Context, string) (bool, error)
+	HasWebAuthnAvailable(context.Context, string) (bool, error)
 	HasNotEnoughLookupSecretsLeft(context.Context, string) (bool, error)
 }
 

--- a/pkg/kratos/service_test.go
+++ b/pkg/kratos/service_test.go
@@ -2654,6 +2654,7 @@ func TestHasWebAuthnAvailableSuccess(t *testing.T) {
 		Id: "test",
 	}
 
+	mockTracer.EXPECT().Start(ctx, "kratos.Service.HasWebAuthnAvailable").Times(1).Return(ctx, trace.SpanFromContext(ctx))
 	mockAdminKratos.EXPECT().IdentityApi().Times(1).Return(mockKratosIdentityApi)
 	mockKratosIdentityApi.EXPECT().GetIdentity(ctx, gomock.Any()).Times(1).Return(identityRequest)
 	mockKratosIdentityApi.EXPECT().GetIdentityExecute(gomock.Any()).Times(1).DoAndReturn(
@@ -2661,6 +2662,7 @@ func TestHasWebAuthnAvailableSuccess(t *testing.T) {
 			return &identity, &resp, nil
 		},
 	)
+	mockLogger.EXPECT().Debugf(gomock.Any(), gomock.Any()).Times(1)
 
 	HasWebAuthnAvailable, err := NewService(mockKratos, mockAdminKratos, mockHydra, mockAuthz, mockTracer, mockMonitor, mockLogger).HasWebAuthnAvailable(ctx, "test")
 
@@ -2672,7 +2674,7 @@ func TestHasWebAuthnAvailableSuccess(t *testing.T) {
 	}
 }
 
-func TestHasWebAuthnAvailableFailonGetIdentityExecute(t *testing.T) {
+func TestHasWebAuthnAvailableFailOnGetIdentityExecute(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -2694,6 +2696,7 @@ func TestHasWebAuthnAvailableFailonGetIdentityExecute(t *testing.T) {
 		ApiService: mockKratosIdentityApi,
 	}
 
+	mockTracer.EXPECT().Start(ctx, "kratos.Service.HasWebAuthnAvailable").Times(1).Return(ctx, trace.SpanFromContext(ctx))
 	mockAdminKratos.EXPECT().IdentityApi().Times(1).Return(mockKratosIdentityApi)
 	mockKratosIdentityApi.EXPECT().GetIdentity(ctx, gomock.Any()).Times(1).Return(identityRequest)
 	mockKratosIdentityApi.EXPECT().GetIdentityExecute(gomock.Any()).Times(1).Return(nil, &resp, fmt.Errorf("error"))

--- a/pkg/web/router.go
+++ b/pkg/web/router.go
@@ -68,7 +68,7 @@ func NewRouter(
 		cookieManager,
 		logger,
 	).RegisterEndpoints(router)
-	extra.NewAPI(extra.NewService(hydraClient, tracer, monitor, logger), kratosService, logger, baseURL, oidcWebAuthnSequencingEnabled).RegisterEndpoints(router)
+	extra.NewAPI(extra.NewService(hydraClient, tracer, monitor, logger), kratosService, baseURL, oidcWebAuthnSequencingEnabled, logger).RegisterEndpoints(router)
 	status.NewAPI(
 		status.NewService(kratosClient.MetadataApi(), hydraClient.MetadataApi(), tracer, monitor, logger),
 		tracer,

--- a/pkg/web/router.go
+++ b/pkg/web/router.go
@@ -30,6 +30,7 @@ func NewRouter(
 	cookieManager *kratos.AuthCookieManager,
 	distFS fs.FS,
 	mfaEnabled bool,
+	oidcWebAuthnSequencingEnabled bool,
 	baseURL string,
 	tracer tracing.TracingInterface,
 	monitor monitoring.MonitorInterface,
@@ -67,7 +68,7 @@ func NewRouter(
 		cookieManager,
 		logger,
 	).RegisterEndpoints(router)
-	extra.NewAPI(extra.NewService(hydraClient, tracer, monitor, logger), kratosService, logger).RegisterEndpoints(router)
+	extra.NewAPI(extra.NewService(hydraClient, tracer, monitor, logger), kratosService, logger, baseURL, oidcWebAuthnSequencingEnabled).RegisterEndpoints(router)
 	status.NewAPI(
 		status.NewService(kratosClient.MetadataApi(), hydraClient.MetadataApi(), tracer, monitor, logger),
 		tracer,

--- a/ui/pages/consent.tsx
+++ b/ui/pages/consent.tsx
@@ -5,6 +5,7 @@ import { useEffect } from "react";
 import { useRouter } from "next/router";
 import React from "react";
 import { LoginFlow } from "@ory/client";
+import { KratosErrorResponse } from "../util/handleFlowError";
 
 export interface FlowResponse {
   data: {
@@ -28,6 +29,7 @@ const Consent: NextPage = () => {
         }
       })
       .catch((err: AxiosError) => {
+        const response = err.response?.data as KratosErrorResponse;
         switch (err.response?.status) {
           case 403:
             // This is a legacy error code thrown. See code 422 for
@@ -42,6 +44,14 @@ const Consent: NextPage = () => {
             return;
           case 401:
             // do nothing, the user is not logged in
+            return;
+          case 303:
+            // This status is returned when user must be redirected
+            // to set up 2fa
+            if (response.error?.id == "session_aal2_required") {
+              window.location.href = response.redirect_browser_to;
+              return;
+            }
             return;
         }
 

--- a/ui/util/handleFlowError.ts
+++ b/ui/util/handleFlowError.ts
@@ -2,7 +2,7 @@ import { AxiosError } from "axios";
 import { Dispatch, SetStateAction } from "react";
 import { toast } from "react-toastify";
 
-interface KratosErrorResponse {
+export interface KratosErrorResponse {
   error?: {
     id: string;
   };


### PR DESCRIPTION
This PR adds support for OIDC and WebAuthn sequencing.

### Testing
Follow the [doc](https://github.com/canonical/identity-platform-login-ui/blob/10b9055ed36d67600f4779c6c8b812591843e549/docs/sequencing.md) to set up a testing environment for this case.

![image](https://github.com/user-attachments/assets/d3c8ea0b-5de5-45b8-aaa4-85e388a1743c)

a. User has no key set up
![image](https://github.com/user-attachments/assets/d7630569-5f9a-4251-b3c8-75a3aeeecd95)

b. User already has a webauthn key
![image](https://github.com/user-attachments/assets/b77ae0fb-b0cb-4455-b150-972e9f80c523)
The "I want to use another method" link must be removed, I'll open an issue for it.
![image](https://github.com/user-attachments/assets/a50bf243-7e45-4747-9c17-783ed41b3e92)

![image](https://github.com/user-attachments/assets/83ed799e-1101-4b16-8598-8867b2b958e7)
