### PR TITLE
feat(ui) improve sequenced login ux

### DIFF
--- a/ui/components/NodeInputButton.tsx
+++ b/ui/components/NodeInputButton.tsx
@@ -3,6 +3,7 @@ import { Button } from "@canonical/react-components";
 import React, { FC, FormEvent } from "react";
 import { NodeInputProps } from "./helpers";
 import { ORY_LABEL_ID_ADD_SECURITY_KEY } from "../util/constants";
+import { isWebauthnAutologin } from "../util/webauthnAutoLogin";
 
 const getWebAuthnPayload = (evalCode: string): unknown => {
   const tmp = evalCode
@@ -51,9 +52,10 @@ export const NodeInputButton: FC<NodeInputProps> = ({
   };
 
   // automatically start the webauthn login
+  const isContinueNode = getNodeLabel(node) === "Continue";
   if (
     onClick?.startsWith("window.oryWebAuthnLogin(") &&
-    getNodeLabel(node) === "Continue"
+    (isWebauthnAutologin() || isContinueNode)
   ) {
     startWebAuthnLogin();
   }

--- a/ui/util/constants.ts
+++ b/ui/util/constants.ts
@@ -14,6 +14,7 @@ const ORY_LABEL_USE_BACKUP_CODE = 1010010;
 const ORY_LABEL_SIGN_IN_EMAIL_INPUT = 1070002;
 const ORY_LABEL_SIGN_IN_WITH_PASSWORD = 1010022;
 const ORY_LABEL_CONTINUE_PASSWORD_RESET = 1070009;
+const ORY_LABEL_SIGN_IN_WITH_HARDWARE_KEY = 1010008;
 
 type NodeWithLabel = UiNode & { meta: { label: object } };
 
@@ -44,5 +45,10 @@ export const isSignInEmailInput = (node: UiNode): node is NodeWithLabel =>
 export const isSignInWithPassword = (node: UiNode): node is NodeWithLabel =>
   node.meta.label?.id === ORY_LABEL_SIGN_IN_WITH_PASSWORD;
 
-export const isContinueWithPasswordReset = (node: UiNode): node is NodeWithLabel =>
+export const isContinueWithPasswordReset = (
+  node: UiNode,
+): node is NodeWithLabel =>
   node.meta.label?.id === ORY_LABEL_CONTINUE_PASSWORD_RESET;
+
+export const isSignInWithHardwareKey = (node: UiNode): node is NodeWithLabel =>
+  node.meta.label?.id === ORY_LABEL_SIGN_IN_WITH_HARDWARE_KEY;

--- a/ui/util/webauthnAutoLogin.tsx
+++ b/ui/util/webauthnAutoLogin.tsx
@@ -1,0 +1,16 @@
+const WEBAUTHN_AUTOLOGIN_KEY = "webauthn_autologin";
+const WEBAUTHN_AUTOLOGIN_VALUE = "true";
+
+export const isWebauthnAutologin = (): boolean => {
+  return (
+    localStorage.getItem(WEBAUTHN_AUTOLOGIN_KEY) === WEBAUTHN_AUTOLOGIN_VALUE
+  );
+};
+
+export const toggleWebauthnSkip = () => {
+  if (isWebauthnAutologin()) {
+    localStorage.removeItem(WEBAUTHN_AUTOLOGIN_KEY);
+  } else {
+    localStorage.setItem(WEBAUTHN_AUTOLOGIN_KEY, WEBAUTHN_AUTOLOGIN_VALUE);
+  }
+};


### PR DESCRIPTION
# Done
- improve UX for sequenced login
- auto redirect to OIDC provider if it is the only login option
- add checkbox to automatically open the passkeys dialogue on landing on next login. Storing the state in local storage.

To-do: blocked by receiving the status from the backend if sequenced login is enabled