### PR TITLE
feat: add endpoint to expose application info

### DIFF
--- a/pkg/status/handlers_test.go
+++ b/pkg/status/handlers_test.go
@@ -31,7 +31,7 @@ func TestAliveOK(t *testing.T) {
 	mockService.EXPECT().BuildInfo(gomock.Any()).Times(1).Return(&BuildInfo{Version: "xyz", Name: "application"})
 
 	mux := chi.NewMux()
-	NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterEndpoints(mux)
+	NewAPI(false, mockService, mockTracer, mockMonitor, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 	res := w.Result()
@@ -66,7 +66,7 @@ func TestHealthSuccess(t *testing.T) {
 	mockService.EXPECT().HydraStatus(gomock.Any()).Times(1).Return(true)
 
 	mux := chi.NewMux()
-	NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterEndpoints(mux)
+	NewAPI(false, mockService, mockTracer, mockMonitor, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 	res := w.Result()
@@ -102,7 +102,7 @@ func TestHealthFailure(t *testing.T) {
 	mockService.EXPECT().KratosStatus(gomock.Any()).Times(1).Return(false)
 	mockService.EXPECT().HydraStatus(gomock.Any()).Times(1).Return(false)
 	mux := chi.NewMux()
-	NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterEndpoints(mux)
+	NewAPI(false, mockService, mockTracer, mockMonitor, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 	res := w.Result()
@@ -120,5 +120,37 @@ func TestHealthFailure(t *testing.T) {
 	}
 	if receivedStatus.Hydra {
 		t.Fatalf("expected Hydra to be false not  %v", receivedStatus.Hydra)
+	}
+}
+
+func TestGetDeploymentInfo(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := NewMockLoggerInterface(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
+	mockTracer := NewMockTracingInterface(ctrl)
+	mockService := NewMockServiceInterface(ctrl)
+	a := NewAPI(false, mockService, mockTracer, mockMonitor, mockLogger)
+
+	req, _ := http.NewRequest(http.MethodGet, "/api/v0/app-config", nil)
+	w := httptest.NewRecorder()
+	a.appConfig(w, req)
+
+	res := w.Result()
+	defer res.Body.Close()
+	data, err := io.ReadAll(res.Body)
+	if err != nil {
+		t.Fatalf("expected error to be nil got %v", err)
+	}
+	receivedInfo := new(DeploymentInfo)
+	if err := json.Unmarshal(data, receivedInfo); err != nil {
+		t.Fatalf("expected error to be nil got %v", err)
+	}
+	if receivedInfo.OidcSequencingEnabled {
+		t.Fatalf("expected sequencing flag to be false not %v", receivedInfo.OidcSequencingEnabled)
+	}
+	if w.Code != http.StatusOK {
+		t.Errorf("expected response code %d, got %d", http.StatusOK, w.Code)
 	}
 }

--- a/pkg/web/router.go
+++ b/pkg/web/router.go
@@ -70,6 +70,7 @@ func NewRouter(
 	).RegisterEndpoints(router)
 	extra.NewAPI(extra.NewService(hydraClient, tracer, monitor, logger), kratosService, baseURL, oidcWebAuthnSequencingEnabled, logger).RegisterEndpoints(router)
 	status.NewAPI(
+		oidcWebAuthnSequencingEnabled,
 		status.NewService(kratosClient.MetadataApi(), hydraClient.MetadataApi(), tracer, monitor, logger),
 		tracer,
 		monitor,


### PR DESCRIPTION
- adds a `GET /api/v0/app-config` endpoint exposing the `OIDC_WEBAUTHN_SEQUENCING_ENABLED` flag value