### PR TITLE
ci(docker): change default settings redirect url for webauthn method

### DIFF
--- a/docker/kratos/kratos.yml
+++ b/docker/kratos/kratos.yml
@@ -43,8 +43,12 @@ selfservice:
                 hooks:
                     - hook: revoke_active_sessions
         settings:
+            # TODO: Replace with self-service settings page when implemented
             ui_url: http://localhost:4455/ui/reset_password
             required_aal: highest_available
+            after:
+                webauthn:
+                    default_browser_return_url: http://localhost:4455/ui/setup_passkey
         registration:
             after:
                 oidc:


### PR DESCRIPTION
This PR changes the default return url for webauthn method, so that the user remains on the setup page after removing or adding a key. This will not influence any redirect when setup is enforced during login.
fixes https://github.com/canonical/identity-platform-login-ui/issues/381

I will open another PR to reflect this in Kratos charm.