### PR TITLE
Uniform POST response redirection

### DIFF
--- a/pkg/kratos/handlers.go
+++ b/pkg/kratos/handlers.go
@@ -332,7 +332,7 @@ func (a *API) handleUpdateFlow(w http.ResponseWriter, r *http.Request) {
 func (a *API) redirectResponse(w http.ResponseWriter, r *http.Request, resp RedirectToInterface) {
 	switch r.Method {
 	case http.MethodGet:
-		w.WriteHeader(http.StatusSeeOther)
+		w.WriteHeader(http.StatusOK)
 		_ = json.NewEncoder(w).Encode(resp)
 	case http.MethodPost:
 		// In case of webauthn the user is redirected here and we get a FORM, instead of JSON.

--- a/pkg/kratos/handlers.go
+++ b/pkg/kratos/handlers.go
@@ -18,6 +18,8 @@ import (
 	"github.com/canonical/identity-platform-login-ui/pkg/ui"
 )
 
+const TOTP_REGISTRATION_REQUIRED = "totp_registration_required"
+const WEBAUTHN_REGISTRATION_REQUIRED = "webauthn_registration_required"
 const RegenerateBackupCodesError = "regenerate_backup_codes"
 const KRATOS_SESSION_COOKIE_NAME = "ory_kratos_session"
 const LOGIN_UI_STATE_COOKIE = "login_ui_state"
@@ -463,7 +465,7 @@ func (a *API) webAuthnSettingsRedirect(w http.ResponseWriter, r *http.Request, r
 		return
 	}
 
-	errorId := "session_aal2_required"
+	errorId := WEBAUTHN_REGISTRATION_REQUIRED
 
 	// Set the original login URL as return_to, to continue the flow after mfa
 	// has been set.
@@ -497,7 +499,7 @@ func (a *API) mfaSettingsRedirect(w http.ResponseWriter, r *http.Request, return
 		return
 	}
 
-	errorId := "session_aal2_required"
+	errorId := TOTP_REGISTRATION_REQUIRED
 
 	// Set the original login URL as return_to, to continue the flow after mfa
 	// has been set.

--- a/pkg/kratos/handlers_test.go
+++ b/pkg/kratos/handlers_test.go
@@ -293,7 +293,7 @@ func TestHandleCreateFlowRedirectToSetupWebauthn(t *testing.T) {
 		t.Errorf("expected error to be nil got %v", err)
 	}
 
-	if res.StatusCode != http.StatusSeeOther {
+	if res.StatusCode != http.StatusOK {
 		t.Fatalf("expected HTTP status code 303 got %v", res.StatusCode)
 	}
 	loginFlow := ErrorBrowserLocationChangeRequired{}

--- a/pkg/kratos/handlers_test.go
+++ b/pkg/kratos/handlers_test.go
@@ -294,14 +294,14 @@ func TestHandleCreateFlowRedirectToSetupWebauthn(t *testing.T) {
 	}
 
 	if res.StatusCode != http.StatusOK {
-		t.Fatalf("expected HTTP status code 303 got %v", res.StatusCode)
+		t.Fatalf("expected HTTP status code 200 got %v", res.StatusCode)
 	}
-	loginFlow := ErrorBrowserLocationChangeRequired{}
+	loginFlow := BrowserLocationChangeRequired{}
 	if err := json.Unmarshal(data, &loginFlow); err != nil {
 		t.Errorf("expected error to be nil got %v", err)
 	}
-	if !strings.HasPrefix(*loginFlow.RedirectBrowserTo, "/ui/setup_passkey") {
-		t.Errorf("expected redirect_browser_to to start with '/ui/setup_passkey' got %v", *loginFlow.RedirectBrowserTo)
+	if !strings.HasPrefix(*loginFlow.RedirectTo, "/ui/setup_passkey") {
+		t.Errorf("expected redirect_to to start with '/ui/setup_passkey' got %v", *loginFlow.RedirectTo)
 	}
 }
 
@@ -315,7 +315,7 @@ func TestHandleCreateFlowWithSession(t *testing.T) {
 
 	session := kClient.NewSession("test")
 	redirect := "https://some/path/to/somewhere"
-	redirectTo := hClient.NewOAuth2RedirectTo(redirect)
+	redirectTo := BrowserLocationChangeRequired{RedirectTo: &redirect}
 
 	loginChallenge := "login_challenge_2341235123231"
 
@@ -326,7 +326,7 @@ func TestHandleCreateFlowWithSession(t *testing.T) {
 
 	mockService.EXPECT().CheckSession(gomock.Any(), req.Cookies()).Return(session, nil, nil)
 	mockService.EXPECT().MustReAuthenticate(gomock.Any(), loginChallenge, session, FlowStateCookie{}).Return(false, nil)
-	mockService.EXPECT().AcceptLoginRequest(gomock.Any(), session, loginChallenge).Return(redirectTo, req.Cookies(), nil)
+	mockService.EXPECT().AcceptLoginRequest(gomock.Any(), session, loginChallenge).Return(&redirectTo, req.Cookies(), nil)
 	mockCookieManager.EXPECT().GetStateCookie(gomock.Any()).Return(FlowStateCookie{}, nil)
 	mockCookieManager.EXPECT().ClearStateCookie(gomock.Any()).Return()
 
@@ -569,9 +569,6 @@ func TestHandleUpdateFlowFailOnParseLoginFlowMethodBody(t *testing.T) {
 	mockCookieManager := NewMockAuthCookieManagerInterface(ctrl)
 
 	flowId := "test"
-	redirectTo := "https://some/path/to/somewhere"
-	flow := new(ErrorBrowserLocationChangeRequired)
-	flow.RedirectBrowserTo = &redirectTo
 
 	flowBody := new(kClient.UpdateLoginFlowBody)
 	flowBody.UpdateLoginFlowWithOidcMethod = kClient.NewUpdateLoginFlowWithOidcMethod("oidc", "oidc")
@@ -658,7 +655,7 @@ func TestHandleUpdateLoginFlowRedirectToRegenerateBackupCodes(t *testing.T) {
 		t.Fatalf("Expected error to be nil got %v", err)
 	}
 	if res.StatusCode != http.StatusOK {
-		t.Fatal("Expected HTTP status code 303, got: ", res.Status)
+		t.Fatal("Expected HTTP status code 200, got: ", res.Status)
 	}
 }
 
@@ -994,9 +991,6 @@ func TestHandleUpdateRecoveryFlowFailOnParseRecoveryFlowMethodBody(t *testing.T)
 	mockCookieManager := NewMockAuthCookieManagerInterface(ctrl)
 
 	flowId := "test"
-	redirectTo := "https://example.com/ui/reset_email"
-	flow := new(ErrorBrowserLocationChangeRequired)
-	flow.RedirectBrowserTo = &redirectTo
 
 	flowBody := new(kClient.UpdateRecoveryFlowBody)
 	flowBody.UpdateRecoveryFlowWithCodeMethod = kClient.NewUpdateRecoveryFlowWithCodeMethod("code")
@@ -1069,6 +1063,9 @@ func TestHandleCreateSettingsFlowWithRedirect(t *testing.T) {
 	redirectErrorBrowserTo := "https://some/path/to/somewhere"
 	redirectFlow := new(BrowserLocationChangeRequired)
 	redirectFlow.RedirectTo = &redirectErrorBrowserTo
+	redirectFlow.Error = kClient.NewGenericErrorWithDefaults()
+	redirectFlow.Error.Code = new(int64)
+	*redirectFlow.Error.Code = 403
 
 	req := httptest.NewRequest(http.MethodGet, HANDLE_CREATE_SETTINGS_FLOW_URL, nil)
 	values := req.URL.Query()
@@ -1192,6 +1189,9 @@ func TestHandleGetSettingsFlowWithRedirect(t *testing.T) {
 	redirectErrorBrowserTo := "https://some/path/to/somewhere"
 	redirectFlow := new(BrowserLocationChangeRequired)
 	redirectFlow.RedirectTo = &redirectErrorBrowserTo
+	redirectFlow.Error = kClient.NewGenericErrorWithDefaults()
+	redirectFlow.Error.Code = new(int64)
+	*redirectFlow.Error.Code = 403
 
 	mockService.EXPECT().GetSettingsFlow(gomock.Any(), id, req.Cookies()).Return(flow, redirectFlow, nil)
 	mockLogger.EXPECT().Errorf(gomock.Any(), gomock.Any()).Times(1)

--- a/pkg/kratos/interfaces.go
+++ b/pkg/kratos/interfaces.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"net/http"
 
-	hClient "github.com/ory/hydra-client-go/v2"
 	kClient "github.com/ory/kratos-client-go"
 
 	"github.com/canonical/identity-platform-login-ui/internal/hydra"
@@ -28,7 +27,7 @@ type AuthorizerInterface interface {
 
 type ServiceInterface interface {
 	CheckSession(context.Context, []*http.Cookie) (*kClient.Session, []*http.Cookie, error)
-	AcceptLoginRequest(context.Context, *kClient.Session, string) (*hClient.OAuth2RedirectTo, []*http.Cookie, error)
+	AcceptLoginRequest(context.Context, *kClient.Session, string) (*BrowserLocationChangeRequired, []*http.Cookie, error)
 	MustReAuthenticate(context.Context, string, *kClient.Session, FlowStateCookie) (bool, error)
 	CreateBrowserLoginFlow(context.Context, string, string, string, bool, []*http.Cookie) (*kClient.LoginFlow, []*http.Cookie, error)
 	CreateBrowserRecoveryFlow(context.Context, string, []*http.Cookie) (*kClient.RecoveryFlow, []*http.Cookie, error)
@@ -67,5 +66,6 @@ type EncryptInterface interface {
 }
 
 type RedirectToInterface interface {
+	GetCode() int
 	GetRedirectTo() string
 }

--- a/pkg/kratos/service_test.go
+++ b/pkg/kratos/service_test.go
@@ -151,6 +151,8 @@ func TestAcceptLoginRequestSuccess(t *testing.T) {
 	session := kClient.NewSession("test")
 	session.Identity = kClient.NewIdentity(identityID, "test.json", "https://test.com/test.json", map[string]string{"name": "name"})
 
+	redirectResp := BrowserLocationChangeRequired{RedirectTo: &redirectTo.RedirectTo}
+
 	session.SetExpiresAt(time.Now().Add(300 * time.Second))
 	leeway := int64(2)
 
@@ -179,8 +181,8 @@ func TestAcceptLoginRequestSuccess(t *testing.T) {
 
 	rt, c, err := NewService(mockKratos, mockAdminKratos, mockHydra, mockAuthz, false, mockTracer, mockMonitor, mockLogger).AcceptLoginRequest(ctx, session, loginChallenge)
 
-	if rt != redirectTo {
-		t.Fatalf("expected redirect to be %v not  %v", redirectTo, rt)
+	if *rt != redirectResp {
+		t.Fatalf("expected redirect to be %v not  %v", redirectResp, *rt)
 	}
 	if !reflect.DeepEqual(c, resp.Cookies()) {
 		t.Fatalf("expected cookies to be %v not  %v", resp.Cookies(), c)

--- a/ui/pages/consent.tsx
+++ b/ui/pages/consent.tsx
@@ -5,7 +5,6 @@ import { useEffect } from "react";
 import { useRouter } from "next/router";
 import React from "react";
 import { LoginFlow } from "@ory/client";
-import { KratosErrorResponse } from "../util/handleFlowError";
 
 export interface FlowResponse {
   data: {
@@ -29,7 +28,6 @@ const Consent: NextPage = () => {
         }
       })
       .catch((err: AxiosError) => {
-        const response = err.response?.data as KratosErrorResponse;
         switch (err.response?.status) {
           case 403:
             // This is a legacy error code thrown. See code 422 for
@@ -44,14 +42,6 @@ const Consent: NextPage = () => {
             return;
           case 401:
             // do nothing, the user is not logged in
-            return;
-          case 303:
-            // This status is returned when user must be redirected
-            // to set up 2fa
-            if (response.error?.id == "session_aal2_required") {
-              window.location.href = response.redirect_browser_to;
-              return;
-            }
             return;
         }
 

--- a/ui/pages/login.tsx
+++ b/ui/pages/login.tsx
@@ -160,10 +160,6 @@ const Login: NextPage = () => {
             window.location.href = data.redirect_to as string;
             return;
           }
-          if ("redirect_browser_to" in data) {
-            window.location.href = data.redirect_browser_to as string;
-            return;
-          }
           if (flow?.return_to) {
             window.location.href = flow.return_to;
             return;

--- a/ui/util/handleFlowError.ts
+++ b/ui/util/handleFlowError.ts
@@ -7,7 +7,12 @@ export interface KratosErrorResponse {
     id: string;
   };
   redirect_browser_to: string;
+  redirect_to: string;
 }
+
+const getRedirectToFromError = (err: KratosErrorResponse) => (
+  window.location.href = err.redirect_browser_to? err.redirect_browser_to: err.redirect_to
+);
 
 // deal with errors coming from initializing a flow.
 export const handleFlowError =
@@ -25,7 +30,7 @@ export const handleFlowError =
       case "session_aal2_required":
         resetFlow(undefined);
         // 2FA is enabled and enforced, but user did not perform 2fa yet!
-        window.location.href = err.response.data.redirect_browser_to;
+        window.location.href = getRedirectToFromError(err.response.data);
         return;
       case "session_already_available":
         // User is already signed in, let's redirect them to settings
@@ -33,7 +38,7 @@ export const handleFlowError =
         return;
       case "session_refresh_required":
         // We need to re-authenticate to perform this action
-        window.location.href = err.response.data.redirect_browser_to;
+        window.location.href = getRedirectToFromError(err.response.data);
         return;
       case "session_inactive":
         // No session found, redirect the user to sign in
@@ -69,11 +74,11 @@ export const handleFlowError =
         return;
       case "browser_location_change_required":
         // Ory Kratos asked us to point the user to this URL.
-        window.location.href = err.response.data.redirect_browser_to;
+        window.location.href = getRedirectToFromError(err.response.data);
         return;
       case "regenerate_backup_codes":
         // The user logged in with a lookup secret and is running out of backup codes, redirect to generate a new set
-        window.location.href = err.response.data.redirect_browser_to;
+        window.location.href = getRedirectToFromError(err.response.data);
         return;
     }
 


### PR DESCRIPTION
IAM-1286

Use `ErrorBrowserLocationChangeRequired` only in the service layer, this is a always converted to `BrowserLocationChangeRequired` before being returned to the handler. Only `BrowserLocationChangeRequired` should be used in the handler from now on. The frontend now has to handle only `BrowserLocationChangeRequired` responses.

All redirect responses to XHR will now return `200 OK`, also thought about using `422` to have similar behavior to kratos. IMO It does not really matter as long as we have a consistent behavior in backend-frontend communications. (cc @natalian98 if you have a suggestion/preference in this)

