### PR TITLE
Fix webauthn for local deployments

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -93,7 +93,7 @@ func serve() {
 		panic("Invalid authorization model provided")
 	}
 
-	router := web.NewRouter(kClient, kAdminClient, hClient, authorizer, cookieManager, distFS, specs.MFAEnabled, specs.OIDCWebAuthnSequencingEnabled, specs.BaseURL, specs.Dev, tracer, monitor, logger)
+	router := web.NewRouter(kClient, kAdminClient, hClient, authorizer, cookieManager, distFS, specs.MFAEnabled, specs.OIDCWebAuthnSequencingEnabled, specs.BaseURL, specs.KratosPublicURL, tracer, monitor, logger)
 
 	logger.Infof("Starting server on port %v", specs.Port)
 

--- a/internal/config/specs.go
+++ b/internal/config/specs.go
@@ -10,7 +10,6 @@ type EnvSpec struct {
 
 	LogLevel string `envconfig:"log_level" default:"error"`
 	Debug    bool   `envconfig:"debug" default:"false"`
-	Dev      bool   `envconfig:"dev" default:"false"`
 
 	Port    int    `envconfig:"port" default:"8080"`
 	BaseURL string `envconfig:"base_url" default:""`

--- a/pkg/web/router.go
+++ b/pkg/web/router.go
@@ -32,7 +32,7 @@ func NewRouter(
 	mfaEnabled bool,
 	oidcWebAuthnSequencingEnabled bool,
 	baseURL string,
-	dev bool,
+	KratosPublicURL string,
 	tracer tracing.TracingInterface,
 	monitor monitoring.MonitorInterface,
 	logger logging.LoggerInterface,
@@ -79,7 +79,7 @@ func NewRouter(
 		monitor,
 		logger,
 	).RegisterEndpoints(router)
-	ui.NewAPI(distFS, dev, logger).RegisterEndpoints(router)
+	ui.NewAPI(distFS, baseURL, KratosPublicURL, logger).RegisterEndpoints(router)
 	metrics.NewAPI(logger).RegisterEndpoints(router)
 
 	return tracing.NewMiddleware(monitor, logger).OpenTelemetry(router)


### PR DESCRIPTION
IAM-1187

Closes #355 

Introduces a new flag that allows localhost:* for the script-src.

I removed `unsafe-inline` from the `script-src`, I could not remove it from the `style-src` because it is required from some library. (cc @edlerd). IMHO we should remove `unsafe-inline` and explicitly specify the hashes of the scripts that we allow to use inline, I would expect this to be handled at the proxy rather than the app itself.