### PR TITLE
feat: handle duplicate identifier error in settings flow

### DIFF
--- a/pkg/kratos/handlers.go
+++ b/pkg/kratos/handlers.go
@@ -702,7 +702,7 @@ func (a *API) handleGetSettingsFlow(w http.ResponseWriter, r *http.Request) {
 	flow, response, err := a.service.GetSettingsFlow(context.Background(), q.Get("id"), r.Cookies())
 	if err != nil {
 		a.logger.Errorf("Error when getting settings flow: %v\n", err)
-		http.Error(w, "Failed to get settings flow", http.StatusInternalServerError)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 


### PR DESCRIPTION
This PR addresses the "Account already exists" case from https://github.com/canonical/identity-platform-login-ui/pull/731#pullrequestreview-3183585923. The backend will return an error when a duplicate account is detected.

Duplicate identifiers are detected as part of `PostSettingsPrePersistHooks`. After signing in at the external IdP, Kratos returns a 200 with an error in the settings flow `ui.nodes.messages` object (see https://www.ory.sh/docs/kratos/reference/api#tag/frontend/operation/getSettingsFlow). This is similar to how we handle some [recovery](https://github.com/canonical/identity-platform-login-ui/blob/a871b592552d7d40d6fe1a6f4ab03f6acce3375c/pkg/kratos/service.go#L373-L381) flow errors.