### PR TITLE
fix: redirect to user details page when session is valid

### DIFF
--- a/internal/misc/http/helpers.go
+++ b/internal/misc/http/helpers.go
@@ -22,6 +22,27 @@ func CookiesToString(cookies []*http.Cookie) string {
 	return strings.Join(ret, "; ")
 }
 
+func FilterCookies(cookies []*http.Cookie, exclude ...string) []*http.Cookie {
+	if len(exclude) == 0 {
+		return cookies
+	}
+
+	ret := make([]*http.Cookie, 0)
+
+	diff := make(map[any]bool)
+	for _, deniedCookieName := range exclude {
+		diff[deniedCookieName] = true
+	}
+
+	for _, cookie := range cookies {
+		if _, ok := diff[cookie.Name]; !ok {
+			ret = append(ret, cookie)
+		}
+	}
+
+	return ret
+}
+
 func GetUserClaims(i kratos_client.Identity, cr hydra_client.OAuth2ConsentRequest) map[string]interface{} {
 	ret := make(map[string]interface{})
 	// Export the user claims and filter them based on the requested scopes

--- a/pkg/kratos/handlers.go
+++ b/pkg/kratos/handlers.go
@@ -145,6 +145,10 @@ func (a *API) handleCreateFlow(w http.ResponseWriter, r *http.Request) {
 			a.cookieManager.ClearStateCookie(w)
 		}
 	} else {
+		// aal is not always a query param, propagate it from session if aal2
+		if isSessionAAL2(session) {
+			aal = "aal2"
+		}
 		response, cookies, err = a.handleCreateFlowNewSession(r, aal, returnTo, loginChallenge, refresh)
 	}
 
@@ -219,6 +223,14 @@ func (a *API) handleCreateFlowWithSession(r *http.Request, session *client.Sessi
 	}
 
 	return response, cookies, nil
+}
+
+func isSessionAAL2(session *client.Session) bool {
+	if session == nil || session.AuthenticatorAssuranceLevel == nil {
+		return false
+	}
+
+	return *session.AuthenticatorAssuranceLevel == client.AUTHENTICATORASSURANCELEVEL_AAL2
 }
 
 func parseGenericError(err error) (*KratosErrorResponse, bool) {

--- a/pkg/kratos/handlers.go
+++ b/pkg/kratos/handlers.go
@@ -5,6 +5,7 @@ import (
 	"crypto/md5"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -36,6 +37,12 @@ type API struct {
 
 	tracer tracing.TracingInterface
 	logger logging.LoggerInterface
+}
+
+type KratosErrorResponse struct {
+	Error             *client.GenericError `json:"error,omitempty"`
+	RedirectBrowserTo string               `json:"redirect_browser_to,omitempty"`
+	RedirectTo        string               `json:"redirect_to,omitempty"`
 }
 
 func (a *API) RegisterEndpoints(mux *chi.Mux) {
@@ -142,6 +149,13 @@ func (a *API) handleCreateFlow(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err != nil {
+		// Propagate the KratosErrorResponse so frontend can handle it
+		if kratosError, ok := parseGenericError(err); ok {
+			w.WriteHeader(http.StatusBadRequest)
+			_ = json.NewEncoder(w).Encode(kratosError)
+			return
+		}
+
 		a.logger.Errorf(err.Error())
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -187,7 +201,7 @@ func (a *API) handleCreateFlowNewSession(r *http.Request, aal, returnTo, loginCh
 		cookies,
 	)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to create login flow, err: %v", err)
+		return nil, nil, fmt.Errorf("failed to create login flow, err: %w", err)
 	}
 
 	flow, err = a.service.FilterFlowProviderList(r.Context(), flow)
@@ -201,10 +215,24 @@ func (a *API) handleCreateFlowNewSession(r *http.Request, aal, returnTo, loginCh
 func (a *API) handleCreateFlowWithSession(r *http.Request, session *client.Session, loginChallenge string) (*BrowserLocationChangeRequired, []*http.Cookie, error) {
 	response, cookies, err := a.service.AcceptLoginRequest(r.Context(), session, loginChallenge)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to accept login request: %v", err)
+		return nil, nil, fmt.Errorf("failed to accept login request: %w", err)
 	}
 
 	return response, cookies, nil
+}
+
+func parseGenericError(err error) (*KratosErrorResponse, bool) {
+	var apiErr *client.GenericOpenAPIError
+	if !errors.As(err, &apiErr) {
+		return nil, false
+	}
+
+	var resp KratosErrorResponse
+	if err := json.Unmarshal(apiErr.Body(), &resp); err != nil {
+		return nil, false
+	}
+
+	return &resp, true
 }
 
 func (a *API) returnToUrl(loginChallenge string) (string, error) {

--- a/pkg/kratos/service.go
+++ b/pkg/kratos/service.go
@@ -1112,6 +1112,8 @@ func (s *Service) ParseIdentifierFirstLoginFlowMethodBody(r *http.Request) (*kCl
 	if err := parseBody(r.Body, &body); err != nil {
 		return nil, cookies, err
 	}
+
+	cookies = httpHelpers.FilterCookies(cookies, KRATOS_SESSION_COOKIE_NAME)
 	return &body, cookies, nil
 }
 
@@ -1190,13 +1192,7 @@ func (s *Service) ParseLoginFlowMethodBody(r *http.Request) (*kClient.UpdateLogi
 
 	// Remove session cookie if this is a 1FA method
 	if s.is1FAMethod(methodPayload.Method) {
-		filtered := make([]*http.Cookie, 0)
-		for _, c := range cookies {
-			if c.Name != KRATOS_SESSION_COOKIE_NAME {
-				filtered = append(filtered, c)
-			}
-		}
-		cookies = filtered
+		cookies = httpHelpers.FilterCookies(cookies, KRATOS_SESSION_COOKIE_NAME)
 	}
 
 	return &ret, cookies, nil

--- a/ui/tests/reset-password.spec.ts
+++ b/ui/tests/reset-password.spec.ts
@@ -7,7 +7,7 @@ import { confirmMailCode, enterNewPassword } from "./helpers/password";
 
 const USER_PASSWORD_NEW = "abcABC123!!!";
 
-test("reset password from oidc app", async ({ context, page }) => {
+test("reset password from oidc app", async ({ browser, context, page }) => {
   resetIdentities();
   await startNewAuthFlow(page);
 
@@ -24,13 +24,17 @@ test("reset password from oidc app", async ({ context, page }) => {
   await expect(page.getByText("Account setup complete")).toBeVisible();
   await finishAuthFlow(page);
 
-  await startNewAuthFlow(page);
+  // Start login in a new context as user is already authenticated within the current context
+  const newContext = await browser.newContext();
+  const newPage = await newContext.newPage();
 
-  await userPassLogin(page, USER_EMAIL, USER_PASSWORD);
-  await expect(page.getByText("Incorrect username or password")).toBeVisible();
+  await startNewAuthFlow(newPage);
 
-  await userPassLogin(page, USER_EMAIL, USER_PASSWORD_NEW);
-  await enterTotpCode(page, totpSetupKey);
+  await userPassLogin(newPage, USER_EMAIL, USER_PASSWORD);
+  await expect(newPage.getByText("Incorrect username or password")).toBeVisible();
 
-  await finishAuthFlow(page);
+  await userPassLogin(newPage, USER_EMAIL, USER_PASSWORD_NEW);
+  await enterTotpCode(newPage, totpSetupKey);
+
+  await finishAuthFlow(newPage);
 });

--- a/ui/tests/use-backup-codes.spec.ts
+++ b/ui/tests/use-backup-codes.spec.ts
@@ -5,7 +5,7 @@ import { resetIdentities } from "./helpers/kratosIdentities";
 import { userPassLogin } from "./helpers/login";
 import { clickButton, verifyBackupCode } from "./helpers/backupCode";
 
-test("backup recovery code setup and usage", async ({ context, page }) => {
+test("backup recovery code setup and usage", async ({ browser, context, page }) => {
   resetIdentities();
   await startNewAuthFlow(page);
   await userPassLogin(page);
@@ -25,11 +25,15 @@ test("backup recovery code setup and usage", async ({ context, page }) => {
 
   await expect(page.getByText("Account setup complete")).toBeVisible();
 
-  await startNewAuthFlow(page);
-  await userPassLogin(page);
+  // Start login in a new context as user is already authenticated within the current context
+  const newContext = await browser.newContext();
+  const newPage = await newContext.newPage();
 
-  await clickButton(page, "Use backup code instead");
-  await verifyBackupCode(page, backupCode);
+  await startNewAuthFlow(newPage);
+  await userPassLogin(newPage);
 
-  await finishAuthFlow(page);
+  await clickButton(newPage, "Use backup code instead");
+  await verifyBackupCode(newPage, backupCode);
+
+  await finishAuthFlow(newPage);
 });

--- a/ui/util/handleFlowError.ts
+++ b/ui/util/handleFlowError.ts
@@ -33,7 +33,7 @@ export const handleFlowError =
         return;
       case "session_already_available":
         // User is already signed in, let's redirect them to settings
-        window.location.href = "./reset_password";
+        window.location.href = "./manage_details";
         return;
       case "session_refresh_required":
         // We need to re-authenticate to perform this action


### PR DESCRIPTION
This PR changes the login flow creation logic:
- Users who are already authenticated are redirected to the User Management page instead of initiating another flow.
- Users without a session or who have not completed 2FA when required proceed with the login flow as before.

closes https://github.com/canonical/identity-platform-login-ui/issues/768
