### PR TITLE
Don't assume csrf token is the first node

### DIFF
--- a/ui/pages/reset_password.tsx
+++ b/ui/pages/reset_password.tsx
@@ -8,7 +8,7 @@ import { handleFlowError } from "../util/handleFlowError";
 import { kratos } from "../api/kratos";
 import PageLayout from "../components/PageLayout";
 import Password from "../components/Password";
-import { UiNodeInputAttributes } from "@ory/client/api";
+import { getCsrfToken } from "../util/getCsrfNode";
 import { AxiosError } from "axios";
 import { FlowResponse } from "./consent";
 import {
@@ -102,8 +102,7 @@ const ResetPassword: NextPage<Props> = ({ forceSelfServe }: Props) => {
         .updateSettingsFlow({
           flow: String(flow?.id),
           updateSettingsFlowBody: {
-            csrf_token: (flow?.ui?.nodes[0].attributes as UiNodeInputAttributes)
-              .value as string,
+            csrf_token: getCsrfToken(flow?.ui?.nodes),
             method: "password",
             password: password,
           },

--- a/ui/pages/setup_backup_codes.tsx
+++ b/ui/pages/setup_backup_codes.tsx
@@ -14,6 +14,7 @@ import PageLayout from "../components/PageLayout";
 import { AxiosError } from "axios";
 import { Spinner } from "@canonical/react-components";
 import { UiNodeInputAttributes } from "@ory/client/api";
+import { getCsrfToken } from "../util/getCsrfNode";
 import {
   isBackupCodeConfirm,
   isBackupCodeConfirmText,
@@ -95,8 +96,7 @@ const SetupBackupCodes: NextPage<Props> = ({ forceSelfServe }: Props) => {
         .updateSettingsFlow({
           flow: String(flow?.id),
           updateSettingsFlowBody: {
-            csrf_token: (flow?.ui?.nodes[0].attributes as UiNodeInputAttributes)
-              .value as string,
+            csrf_token: getCsrfToken(flow?.ui?.nodes),
             method: "lookup_secret",
             lookup_secret_reveal: methodValues.lookup_secret_reveal
               ? true

--- a/ui/pages/setup_passkey.tsx
+++ b/ui/pages/setup_passkey.tsx
@@ -15,6 +15,7 @@ import PageLayout from "../components/PageLayout";
 import { AxiosError } from "axios";
 import { Button, Icon, Spinner } from "@canonical/react-components";
 import { UpdateSettingsFlowWithWebAuthnMethod } from "@ory/client/api";
+import { getCsrfToken } from "../util/getCsrfNode";
 import {
   isSecurityKeyAddBtn,
   isSecurityKeyNameInput,
@@ -113,8 +114,7 @@ const SetupPasskey: NextPage<Props> = ({ forceSelfServe }: Props) => {
         .updateSettingsFlow({
           flow: String(flow?.id),
           updateSettingsFlowBody: {
-            csrf_token: (flow?.ui?.nodes[0].attributes as UiNodeInputAttributes)
-              .value as string,
+            csrf_token: getCsrfToken(flow?.ui?.nodes),
             method: "webauthn",
             webauthn_remove: authValues.webauthn_remove,
           },

--- a/ui/pages/setup_secure.tsx
+++ b/ui/pages/setup_secure.tsx
@@ -13,7 +13,7 @@ import { kratos } from "../api/kratos";
 import PageLayout from "../components/PageLayout";
 import { AxiosError } from "axios";
 import { Notification, Spinner } from "@canonical/react-components";
-import { UiNodeInputAttributes } from "@ory/client/api";
+import { getCsrfToken } from "../util/getCsrfNode";
 import {
   getLoggedInName,
   hasSelfServeReturn,
@@ -89,8 +89,7 @@ const SetupSecure: NextPage<Props> = ({ forceSelfServe }: Props) => {
         .updateSettingsFlow({
           flow: String(flow?.id),
           updateSettingsFlowBody: {
-            csrf_token: (flow?.ui?.nodes[0].attributes as UiNodeInputAttributes)
-              .value as string,
+            csrf_token: getCsrfToken(flow?.ui?.nodes),
             method: "totp",
             totp_code: methodValues.totp_code,
             totp_unlink: methodValues.totp_unlink ? true : undefined,

--- a/ui/util/getCsrfNode.ts
+++ b/ui/util/getCsrfNode.ts
@@ -1,0 +1,21 @@
+import { UiNode, UiNodeInputAttributes } from "@ory/client";
+
+export const getCsrfNode = (
+  nodes?: UiNode[],
+): UiNode | undefined =>
+  nodes?.find(
+    (node) =>
+      node.group === "default" &&
+      // ensure it's an input node with the csrf token name
+      (node.attributes as UiNodeInputAttributes | undefined)?.node_type ===
+        "input" &&
+      (node.attributes as UiNodeInputAttributes | undefined)?.name ===
+        "csrf_token",
+  );
+
+export const getCsrfToken = (nodes?: UiNode[]): string | undefined => {
+  const node = getCsrfNode(nodes);
+  return (node?.attributes as UiNodeInputAttributes | undefined)?.value as
+    | string
+    | undefined;
+};


### PR DESCRIPTION
The behaviour seems to be inconsistent in the latest version of kratos, so we adopt the `find()` pattern used elsewhere in the code.

Fixes https://github.com/canonical/kratos-operator/issues/579