### PR TITLE
feat: support profile settings method and prevent email impersonation

### DIFF
--- a/pkg/kratos/service.go
+++ b/pkg/kratos/service.go
@@ -989,20 +989,31 @@ func (s *Service) ParseRegistrationFlowMethodBody(r *http.Request) (*kClient.Upd
 	return &ret, nil
 }
 
+func extractProfileTraits(raw map[string]any) map[string]any {
+	traits := make(map[string]any)
+
+	if nested, ok := raw["traits"].(map[string]any); ok {
+		for k, v := range nested {
+			traits[k] = v
+		}
+	}
+
+	for k, v := range raw {
+		if strings.HasPrefix(k, "traits.") {
+			traits[strings.TrimPrefix(k, "traits.")] = v
+		}
+	}
+
+	return traits
+}
+
 func parseProfileBody(body io.ReadCloser) (*kClient.UpdateRegistrationFlowWithProfileMethod, error) {
 	var raw map[string]interface{}
 	if err := json.NewDecoder(body).Decode(&raw); err != nil {
 		return nil, err
 	}
 
-	traits := make(map[string]interface{})
-	for k, v := range raw {
-		if strings.HasPrefix(k, "traits.") {
-			key := strings.TrimPrefix(k, "traits.")
-			traits[key] = v
-			delete(raw, k)
-		}
-	}
+	traits := extractProfileTraits(raw)
 
 	profileBody := kClient.UpdateRegistrationFlowWithProfileMethod{
 		Method: "profile",
@@ -1348,11 +1359,58 @@ func (s *Service) ParseSettingsFlowMethodBody(r *http.Request) (*kClient.UpdateS
 		}
 		ret = kClient.UpdateSettingsFlowWithLookupMethodAsUpdateSettingsFlowBody(&body)
 
+	case "profile":
+		profileBody, err := s.parseSettingsProfileMethod(r, bodyBytes)
+		if err != nil {
+			return nil, err
+		}
+
+		ret = kClient.UpdateSettingsFlowWithProfileMethodAsUpdateSettingsFlowBody(profileBody)
+
 	default:
-		return nil, fmt.Errorf("upsupported method: %s", methodPayload.Method)
+		return nil, fmt.Errorf("unsupported method: %s", methodPayload.Method)
 	}
 
 	return &ret, nil
+}
+
+func (s *Service) parseSettingsProfileMethod(r *http.Request, bodyBytes []byte) (*kClient.UpdateSettingsFlowWithProfileMethod, error) {
+	var raw map[string]any
+	if err := json.Unmarshal(bodyBytes, &raw); err != nil {
+		return nil, fmt.Errorf("failed to parse profile body: %w", err)
+	}
+
+	traits := extractProfileTraits(raw)
+
+	// Remove the email trait if present in the request
+	delete(traits, "email")
+
+	session, _, err := s.CheckSession(r.Context(), r.Cookies())
+	if err != nil {
+		return nil, fmt.Errorf("failed to verify session for profile update: %w", err)
+	}
+
+	if session == nil || session.Identity == nil {
+		return nil, fmt.Errorf("invalid session state: identity is missing")
+	}
+
+	// Inject the current user email and preserve other existing traits
+	// so they are not unset when omitted in the request payload
+	identityTraits, ok := session.Identity.Traits.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("internal error: could not parse existing user traits")
+	}
+
+	for k, v := range traits {
+		identityTraits[k] = v
+	}
+	profileBody := kClient.NewUpdateSettingsFlowWithProfileMethod("profile", identityTraits)
+
+	if csrf, ok := raw["csrf_token"].(string); ok {
+		profileBody.SetCsrfToken(csrf)
+	}
+
+	return profileBody, nil
 }
 
 func (s *Service) contains(str []string, e string) bool {

--- a/pkg/kratos/service_test.go
+++ b/pkg/kratos/service_test.go
@@ -3576,6 +3576,130 @@ func TestUpdateSettingsFlowForbiddenStatus(t *testing.T) {
 	}
 }
 
+func TestParseSettingsFlowProfileMethodBodySuccess(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := NewMockLoggerInterface(ctrl)
+	mockHydra := NewMockHydraClientInterface(ctrl)
+	mockKratos := NewMockKratosClientInterface(ctrl)
+	mockAdminKratos := NewMockKratosAdminClientInterface(ctrl)
+	mockAuthz := NewMockAuthorizerInterface(ctrl)
+	mockTracer := NewMockTracingInterface(ctrl)
+	mockMonitor := monitoring.NewMockMonitorInterface(ctrl)
+	mockKratosFrontendApi := NewMockFrontendAPI(ctrl)
+
+	ctx := context.Background()
+
+	session := kClient.NewSession("test-session")
+	session.Identity = kClient.NewIdentity("id", "schema", "url", map[string]any{
+		"email": "test@example.com",
+		"name":  "Old Name",
+	})
+	sessionRequest := kClient.FrontendAPIToSessionRequest{
+		ApiService: mockKratosFrontendApi,
+	}
+
+	mockTracer.EXPECT().Start(gomock.Any(), "kratos.Service.ToSession").Times(1).Return(ctx, trace.SpanFromContext(ctx))
+	mockKratos.EXPECT().FrontendApi().Times(1).Return(mockKratosFrontendApi)
+	mockKratosFrontendApi.EXPECT().ToSession(gomock.Any()).Times(1).Return(sessionRequest)
+	mockKratosFrontendApi.EXPECT().ToSessionExecute(gomock.Any()).Times(1).Return(session, &http.Response{}, nil)
+
+	// User attempts to change email while updating profile
+	payload := map[string]any{
+		"method":     "profile",
+		"csrf_token": "token123",
+		"traits": map[string]any{
+			"email": "impersonated@example.com",
+			"name":  "New Name",
+		},
+	}
+	jsonBody, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("failed to marshal payload: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "http://some/path", io.NopCloser(bytes.NewBuffer(jsonBody)))
+
+	svc := NewService(mockKratos, mockAdminKratos, mockHydra, mockAuthz, false, mockTracer, mockMonitor, mockLogger)
+	b, err := svc.ParseSettingsFlowMethodBody(req)
+
+	if err != nil {
+		t.Fatalf("expected error to be nil, got %v", err)
+	}
+
+	profileMethod := b.UpdateSettingsFlowWithProfileMethod
+	if profileMethod == nil {
+		t.Fatalf("expected profile method, got nil")
+	}
+
+	if *profileMethod.CsrfToken != "token123" {
+		t.Fatalf("expected csrf_token to be token123, got %s", *profileMethod.CsrfToken)
+	}
+
+	traits := profileMethod.Traits
+	if traits == nil {
+		t.Fatalf("expected traits to not be nil")
+	}
+
+	if traits["email"] != "test@example.com" {
+		t.Fatalf("expected email to be unchanged (test@example.com), got %v", traits["email"])
+	}
+	if traits["name"] != "New Name" {
+		t.Fatalf("expected name to be updated (New Name), got %v", traits["name"])
+	}
+}
+
+func TestParseSettingsFlowProfileMethodBodySessionFail(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := NewMockLoggerInterface(ctrl)
+	mockHydra := NewMockHydraClientInterface(ctrl)
+	mockKratos := NewMockKratosClientInterface(ctrl)
+	mockAdminKratos := NewMockKratosAdminClientInterface(ctrl)
+	mockAuthz := NewMockAuthorizerInterface(ctrl)
+	mockTracer := NewMockTracingInterface(ctrl)
+	mockMonitor := monitoring.NewMockMonitorInterface(ctrl)
+	mockKratosFrontendApi := NewMockFrontendAPI(ctrl)
+
+	ctx := context.Background()
+
+	sessionRequest := kClient.FrontendAPIToSessionRequest{
+		ApiService: mockKratosFrontendApi,
+	}
+
+	mockTracer.EXPECT().Start(gomock.Any(), "kratos.Service.ToSession").Times(1).Return(ctx, trace.SpanFromContext(ctx))
+	mockKratos.EXPECT().FrontendApi().Times(1).Return(mockKratosFrontendApi)
+	mockKratosFrontendApi.EXPECT().ToSession(gomock.Any()).Times(1).Return(sessionRequest)
+	mockKratosFrontendApi.EXPECT().ToSessionExecute(gomock.Any()).Times(1).Return(nil, &http.Response{}, fmt.Errorf("session invalid or expired"))
+
+	payload := map[string]any{
+		"method":     "profile",
+		"csrf_token": "token123",
+		"traits": map[string]any{
+			"name": "New Name",
+		},
+	}
+	jsonBody, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("failed to marshal payload: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "http://some/path", io.NopCloser(bytes.NewBuffer(jsonBody)))
+
+	svc := NewService(mockKratos, mockAdminKratos, mockHydra, mockAuthz, false, mockTracer, mockMonitor, mockLogger)
+
+	_, err = svc.ParseSettingsFlowMethodBody(req)
+
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "session invalid or expired") {
+		t.Fatalf("expected session error, got %v", err)
+	}
+}
+
 func TestHasNotEnoughLookupSecretsLeftSuccess(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()


### PR DESCRIPTION
## Summary
This PR adds backend support for the profile method in the settings flow.
- To prevent email Impersonation, the email parameter is explicitly dropped from profile update payloads. This ensures users cannot alter their identifier to impersonate another user via a profile update.
- Kratos performs a full replacement of the traits object and requires the email field in the payload. This implementation fetches the user's identity and merges the incoming updates with their existing traits to preserve the original email and any unmodified data.

## Testing
Go to reset password page, submit a new password and copy the POST request as curl. Modify the payload with `"method": "profile","traits":{"email":"a@b.com", "name": "New Name"}`, for example:
```
curl 'http://localhost/self-service/settings?flow=8282a0dc-8d76-45fc-b986-95e251aaff45' \
  -H 'Accept: application/json, text/plain, */*' \
  -H 'Accept-Language: en-US,en;q=0.9' \
  -H 'Connection: keep-alive' \
  -H 'Content-Type: application/json' \
  -b 'ory_hydra_login_csrf_dev_<redacted>; csrf_token_<redacted>; ory_kratos_session=<redacted>; ory_hydra_session_dev=<redacted>; ory_hydra_consent_csrf_dev_<redacted>' \
  -H 'Origin: http://localhost' \
  -H 'Referer: http://localhost/ui/reset_password?flow=8282a0dc-8d76-45fc-b986-95e251aaff45' \
  -H 'Sec-Fetch-Dest: empty' \
  -H 'Sec-Fetch-Mode: cors' \
  -H 'Sec-Fetch-Site: same-origin' \
  -H 'User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/145.0.0.0 Safari/537.36' \
  -H 'sec-ch-ua: "Chromium";v="145", "Not:A-Brand";v="99"' \
  -H 'sec-ch-ua-mobile: ?0' \
  -H 'sec-ch-ua-platform: "Linux"' \
  --data-raw $'{"csrf_token":"<redacted>","method":"profile","traits":{"email":"a@b.com", "name": "New Name"}}'
```

Then `curl http://localhost:4434/admin/identities` to verify that the name was updated but the email remained unchanged.