### PR TITLE
feat: allow different port for login-ui related endpoint in kratos config

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,12 @@ CLIENT_SECRET=<client_secret>
 
 From the root folder of the repository, run the docker-compose:
 ```shell
-docker compose up
+docker compose -f docker-compose.dev.yml up --build
+```
+
+For frontend development, you can easily tell the kratos instance to use port 3001 for login-ui endpoints by running docker compose with the LOGIN_UI_BASE_URL env var:
+```shell
+LOGIN_UI_BASE_URL=http://localhost:3001 docker compose up
 ```
 
 To test the authorization code flow you can use the Ory Hydra CLI:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -49,6 +49,20 @@ services:
       - LOG_LEVEL=trace
       - SELFSERVICE_METHODS_OIDC_CONFIG_PROVIDERS_0_CLIENT_ID=${CLIENT_ID}
       - SELFSERVICE_METHODS_OIDC_CONFIG_PROVIDERS_0_CLIENT_SECRET=${CLIENT_SECRET}
+
+      - SERVE_PUBLIC_BASE_URL=${LOGIN_UI_BASE_URL:-http://localhost}/
+      - SELFSERVICE_ALLOWED_RETURN_URLS_0=${LOGIN_UI_BASE_URL:-http://localhost}/ui/
+      - SELFSERVICE_DEFAULT_BROWSER_RETURN_URL=${LOGIN_UI_BASE_URL:-http://localhost}/ui/manage_details
+      - SELFSERVICE_FLOWS_ERROR_UI_URL=${LOGIN_UI_BASE_URL:-http://localhost}/ui/error
+      - SELFSERVICE_FLOWS_LOGIN_UI_URL=${LOGIN_UI_BASE_URL:-http://localhost}/ui/login
+      - SELFSERVICE_FLOWS_RECOVERY_UI_URL=${LOGIN_UI_BASE_URL:-http://localhost}/ui/reset_email
+      - SELFSERVICE_FLOWS_SETTINGS_UI_URL=${LOGIN_UI_BASE_URL:-http://localhost}/ui/reset_password
+      - SELFSERVICE_FLOWS_SETTINGS_AFTER_OIDC_DEFAULT_BROWSER_RETURN_URL=${LOGIN_UI_BASE_URL:-http://localhost}/ui/manage_connected_accounts
+      - SELFSERVICE_FLOWS_SETTINGS_AFTER_WEBAUTHN_DEFAULT_BROWSER_RETURN_URL=${LOGIN_UI_BASE_URL:-http://localhost}/ui/setup_passkey
+      - SELFSERVICE_FLOWS_REGISTRATION_UI_URL=${LOGIN_UI_BASE_URL:-http://localhost}/ui/register
+      - SELFSERVICE_FLOWS_VERIFICATION_UI_URL=${LOGIN_UI_BASE_URL:-http://localhost}/ui/verification
+      - SELFSERVICE_METHODS_WEBAUTHN_CONFIG_RP_ORIGINS_0=${LOGIN_UI_BASE_URL:-http://localhost}
+
     command: exec kratos serve -c /etc/config/kratos/kratos.yml --dev --watch-courier
     volumes:
       - type: volume

--- a/ui/package.json
+++ b/ui/package.json
@@ -17,9 +17,9 @@
   },
   "scripts": {
     "clean": "rm -rf node_modules css static/css *.log _site/ .next/",
-    "dev": "next dev",
+    "dev": "next dev -p 3001",
     "build": "next build",
-    "start": "next start",
+    "start": "next start -p 3001",
     "lint": "next lint",
     "fix-lint": "next lint --fix"
   },


### PR DESCRIPTION
## Description

This PR adds the use of an env var (with sensible default) to easily allow frontend developers to work on the frontend with hot module reload wihtout changing the kratos config, risking to push unwanted changes.

This leverages the kratos config env var to override the login ui URLs, since when working on the frontend the next.js app runs on port 3001.