### PR TITLE
Enforce verification on login

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -124,7 +124,7 @@ func buildRouter(specs *config.EnvSpec, distFS fs.FS, logger *logging.Logger) (h
 		web.WithAuthzClient(authorizer),
 		web.WithCookieManager(cookieManager),
 		web.WithFS(distFS),
-		web.WithFlags(specs.MFAEnabled, specs.OIDCWebAuthnSequencingEnabled, specs.IdentifierFirstEnabled),
+		web.WithFlags(specs.VerificationEnabled, specs.MFAEnabled, specs.OIDCWebAuthnSequencingEnabled, specs.IdentifierFirstEnabled),
 		web.WithBaseURL(specs.BaseURL),
 		web.WithSupportEmail(specs.SupportEmail),
 		web.WithFeatureFlags(specs.FeatureFlags),

--- a/docker/kratos/kratos.yml
+++ b/docker/kratos/kratos.yml
@@ -33,13 +33,7 @@ selfservice:
             ui_url: http://localhost/ui/error
         login:
             ui_url: http://localhost/ui/login
-            # TODO: Uncomment when the pattern is implemented in FE
             style: identifier_first
-            # uncomment this block after verification-post-login has been addressed
-            # after:
-            #     password:
-            #         hooks:
-            #             - hook: require_verified_address
         recovery:
             enabled: True
             ui_url: http://localhost/ui/reset_email

--- a/internal/config/specs.go
+++ b/internal/config/specs.go
@@ -28,6 +28,7 @@ type EnvSpec struct {
     AuthorizationModelId string `envconfig:"openfga_authorization_model_id" default:""`
     AuthorizationEnabled bool   `envconfig:"authorization_enabled" default:"false"`
 
+    VerificationEnabled           bool     `envconfig:"verification_enabled" default:"false"`
     MFAEnabled                    bool     `envconfig:"mfa_enabled" default:"true"`
     OIDCWebAuthnSequencingEnabled bool     `envconfig:"oidc_webauthn_sequencing_enabled" default:"false"`
     IdentifierFirstEnabled        bool     `envconfig:"identifier_first_enabled" default:"true"`

--- a/pkg/kratos/handlers.go
+++ b/pkg/kratos/handlers.go
@@ -21,6 +21,7 @@ import (
 	"github.com/canonical/identity-platform-login-ui/pkg/ui"
 )
 
+const VERIFICATION_REQUIRED = "verification_required"
 const TOTP_REGISTRATION_REQUIRED = "totp_registration_required"
 const WEBAUTHN_REGISTRATION_REQUIRED = "webauthn_registration_required"
 const RegenerateBackupCodesError = "regenerate_backup_codes"
@@ -30,6 +31,7 @@ const LOGIN_UI_STATE_COOKIE = "login_ui_state"
 const SECURITY_CSRF_VIOLATION_ERROR = "security_csrf_violation"
 
 type API struct {
+	verificationEnabled           bool
 	mfaEnabled                    bool
 	oidcWebAuthnSequencingEnabled bool
 	service                       ServiceInterface
@@ -105,6 +107,18 @@ func (a *API) handleCreateFlow(w http.ResponseWriter, r *http.Request) {
 	// TODO: We need to send a different content-type to CreateBrowserLoginFlow in order to avoid this bug.
 	session, _, _ := a.service.CheckSession(r.Context(), r.Cookies())
 	if session != nil {
+		shouldEnforceVerification, unverifiedEmail, err := a.shouldEnforceVerificationWithSession(r.Context(), session)
+		if err != nil {
+			a.logger.Errorf("failed check for verification status: %v", err)
+			http.Error(w, "Failed check for verification", http.StatusInternalServerError)
+			return
+		}
+		if shouldEnforceVerification {
+			flowCookie := FlowStateCookie{LoginChallengeHash: hash(loginChallenge)}
+			a.verificationRedirect(w, r, returnTo, flowCookie, unverifiedEmail)
+			return
+		}
+
 		shouldEnforceMfa, err = a.shouldEnforceMFAWithSession(r.Context(), session)
 
 		if err != nil {
@@ -439,6 +453,14 @@ func (a *API) handleUpdateFlow(w http.ResponseWriter, r *http.Request) {
 	lc := u.Query().Get("login_challenge")
 	flowCookie := FlowStateCookie{LoginChallengeHash: hash(lc)}
 
+	shouldEnforceVerification, unverifiedEmail, err := a.shouldEnforceVerification(r.Context(), cookies)
+	if err != nil {
+		err = fmt.Errorf("verification enforce check error: %v", err)
+		a.logger.Error(err.Error())
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
 	shouldEnforceMfa, err := a.shouldEnforceMFA(r.Context(), cookies)
 	if err != nil {
 		err = fmt.Errorf("enforce check error: %v", err)
@@ -457,6 +479,12 @@ func (a *API) handleUpdateFlow(w http.ResponseWriter, r *http.Request) {
 	}
 
 	setCookies(w, cookies)
+
+	if shouldEnforceVerification {
+		// redirect to verification ui and pass the original returnTo so the flow continues after verification
+		a.verificationRedirect(w, r, *loginFlow.ReturnTo, flowCookie, unverifiedEmail)
+		return
+	}
 
 	if shouldRegenerateBackupCodes {
 		a.lookupSecretsSettingsRedirect(w, r, flowId, *loginFlow.ReturnTo, flowCookie)
@@ -513,6 +541,80 @@ func (a *API) handleUpdateFlow(w http.ResponseWriter, r *http.Request) {
 
 	w.WriteHeader(http.StatusOK)
 	w.Write(resp)
+}
+
+func (a *API) shouldEnforceVerification(ctx context.Context, cookies []*http.Cookie) (bool, string, error) {
+	ctx, span := a.tracer.Start(ctx, "kratos.API.shouldEnforceVerification")
+	defer span.End()
+
+	if !a.verificationEnabled {
+		return false, "", nil
+	}
+
+	session, _, err := a.service.CheckSession(ctx, cookies)
+	if err != nil {
+		if a.is40xError(err) {
+			a.logger.Debugf("check session failed: %v", err)
+			return false, "", nil
+		}
+		return false, "", err
+	}
+
+	return a.shouldEnforceVerificationWithSession(ctx, session)
+}
+
+func (a *API) shouldEnforceVerificationWithSession(ctx context.Context, session *client.Session) (bool, string, error) {
+	ctx, span := a.tracer.Start(ctx, "kratos.API.shouldEnforceVerificationWithSession")
+	defer span.End()
+
+	if !a.verificationEnabled {
+		return false, "", nil
+	}
+
+	if session == nil {
+		return false, "", nil
+	}
+
+	shouldEnforceVerification, unverifiedEmail, err := a.service.RequireVerificationForEmail(ctx, session)
+	if err != nil {
+		a.logger.Debugf("verification check failed: %v", err)
+		return false, "", err
+	}
+
+	return shouldEnforceVerification, unverifiedEmail, nil
+}
+
+func (a *API) verificationRedirect(w http.ResponseWriter, r *http.Request, returnTo string, flowStateCookie FlowStateCookie, email string) {
+	redirect, err := url.JoinPath("/", a.contextPath, "/ui/verification")
+	if err != nil {
+		a.logger.Error(err.Error())
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// set return_to so that after verification the user is sent back to resume the login flow
+	redirectTo, err := url.ParseRequestURI(redirect)
+	if err != nil {
+		a.logger.Error(err.Error())
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	q := redirectTo.Query()
+	q.Set("return_to", returnTo)
+	// add email to query params so that the verification ui directly asks for code sent to that email
+	if email != "" {
+		q.Set("email", email)
+	}
+	redirectTo.RawQuery = q.Encode()
+	rt := redirectTo.String()
+	errorId := VERIFICATION_REQUIRED
+
+	a.cookieManager.SetStateCookie(w, flowStateCookie)
+	a.redirectResponse(w, r, &BrowserLocationChangeRequired{
+		Error:      &client.GenericError{Id: &errorId},
+		RedirectTo: &rt,
+	})
 }
 
 func (a *API) redirectResponse(w http.ResponseWriter, r *http.Request, resp RedirectToInterface) {
@@ -1136,6 +1238,7 @@ func kratosSessionUnsetCookie() *http.Cookie {
 
 func NewAPI(
 	service ServiceInterface,
+	verificationEnabled,
 	mfaEnabled,
 	oidcWebAuthnSequencingEnabled bool,
 	baseURL string,
@@ -1144,6 +1247,7 @@ func NewAPI(
 	logger logging.LoggerInterface) *API {
 	a := new(API)
 
+	a.verificationEnabled = verificationEnabled
 	a.mfaEnabled = mfaEnabled
 	a.oidcWebAuthnSequencingEnabled = oidcWebAuthnSequencingEnabled
 	a.service = service

--- a/pkg/kratos/handlers_test.go
+++ b/pkg/kratos/handlers_test.go
@@ -1,10 +1,10 @@
 package kratos
 
 import (
-    "bytes"
+	"bytes"
 	"context"
 	"encoding/json"
-    "errors"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -59,7 +59,7 @@ func TestHandleCreateFlowWithoutParams(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, false, false, BASE_URL, mockCookieManager, mockTracer, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, false, false, false, BASE_URL, mockCookieManager, mockTracer, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -101,7 +101,7 @@ func TestHandleCreateFlowWithoutSessionAcceptJSON(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, false, false, BASE_URL, mockCookieManager, mockTracer, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, false, false, false, BASE_URL, mockCookieManager, mockTracer, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -155,7 +155,7 @@ func TestHandleCreateFlowWithoutSessionNotAcceptJSON(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, false, false, BASE_URL, mockCookieManager, mockTracer, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, false, false, false, BASE_URL, mockCookieManager, mockTracer, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -202,7 +202,7 @@ func TestHandleCreateFlowWithoutSessionFailOnCreateBrowserLoginFlow(t *testing.T
 
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, false, false, BASE_URL, mockCookieManager, mockTracer, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, false, false, false, BASE_URL, mockCookieManager, mockTracer, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -244,7 +244,7 @@ func TestHandleCreateFlowWithoutSessionFailOnFilterProviders(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, false, false, BASE_URL, mockCookieManager, mockTracer, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, false, false, false, BASE_URL, mockCookieManager, mockTracer, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -287,7 +287,7 @@ func TestHandleCreateFlowWithoutSessionWhenNoProvidersAllowedAcceptJSON(t *testi
 
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, false, false, BASE_URL, mockCookieManager, mockTracer, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, false, false, false, BASE_URL, mockCookieManager, mockTracer, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -342,7 +342,7 @@ func TestHandleCreateFlowWithoutSessionWhenNoProvidersAllowedNotAcceptJSON(t *te
 
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, false, false, BASE_URL, mockCookieManager, mockTracer, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, false, false, false, BASE_URL, mockCookieManager, mockTracer, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -388,6 +388,7 @@ func TestHandleCreateFlowRedirectToSetupWebauthn(t *testing.T) {
 	req.URL.RawQuery = values.Encode()
 
 	mockService.EXPECT().CheckSession(gomock.Any(), req.Cookies()).Return(session, nil, nil)
+	mockTracer.EXPECT().Start(gomock.Any(), "kratos.API.shouldEnforceVerificationWithSession").Return(context.Background(), trace.SpanFromContext(context.Background())).AnyTimes()
 	mockTracer.EXPECT().Start(gomock.Any(), "kratos.API.shouldEnforceMFAWithSession").Return(context.Background(), trace.SpanFromContext(context.Background())).AnyTimes()
 	mockTracer.EXPECT().Start(gomock.Any(), "kratos.API.shouldEnforceWebAuthnWithSession").Return(context.Background(), trace.SpanFromContext(context.Background())).AnyTimes()
 	mockService.EXPECT().HasWebAuthnAvailable(gomock.Any(), session.Id).Return(false, nil)
@@ -395,7 +396,7 @@ func TestHandleCreateFlowRedirectToSetupWebauthn(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, false, true, BASE_URL, mockCookieManager, mockTracer, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, false, false, true, BASE_URL, mockCookieManager, mockTracer, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -440,6 +441,7 @@ func TestHandleCreateFlowWithSessionAcceptJSON(t *testing.T) {
 	req.Header.Set("Accept", "application/json, text/plain, */*")
 
 	mockService.EXPECT().CheckSession(gomock.Any(), req.Cookies()).Return(session, nil, nil)
+	mockTracer.EXPECT().Start(gomock.Any(), "kratos.API.shouldEnforceVerificationWithSession").Return(context.Background(), trace.SpanFromContext(context.Background())).AnyTimes()
 	mockTracer.EXPECT().Start(gomock.Any(), "kratos.API.shouldEnforceMFAWithSession").Return(context.Background(), trace.SpanFromContext(context.Background())).AnyTimes()
 	mockTracer.EXPECT().Start(gomock.Any(), "kratos.API.shouldEnforceWebAuthnWithSession").Return(context.Background(), trace.SpanFromContext(context.Background())).AnyTimes()
 	mockService.EXPECT().MustReAuthenticate(gomock.Any(), loginChallenge, session, FlowStateCookie{}).Return(false, nil)
@@ -449,7 +451,7 @@ func TestHandleCreateFlowWithSessionAcceptJSON(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, false, false, BASE_URL, mockCookieManager, mockTracer, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, false, false, false, BASE_URL, mockCookieManager, mockTracer, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -493,6 +495,7 @@ func TestHandleCreateFlowWithSessionNotAcceptJSON(t *testing.T) {
 	req.Header.Set("Accept", "application/x-www-form-urlencoded")
 
 	mockService.EXPECT().CheckSession(gomock.Any(), req.Cookies()).Return(session, nil, nil)
+	mockTracer.EXPECT().Start(gomock.Any(), "kratos.API.shouldEnforceVerificationWithSession").Return(context.Background(), trace.SpanFromContext(context.Background())).AnyTimes()
 	mockTracer.EXPECT().Start(gomock.Any(), "kratos.API.shouldEnforceMFAWithSession").Return(context.Background(), trace.SpanFromContext(context.Background())).AnyTimes()
 	mockTracer.EXPECT().Start(gomock.Any(), "kratos.API.shouldEnforceWebAuthnWithSession").Return(context.Background(), trace.SpanFromContext(context.Background())).AnyTimes()
 	mockService.EXPECT().MustReAuthenticate(gomock.Any(), loginChallenge, session, FlowStateCookie{}).Return(false, nil)
@@ -502,7 +505,7 @@ func TestHandleCreateFlowWithSessionNotAcceptJSON(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, false, false, BASE_URL, mockCookieManager, mockTracer, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, false, false, false, BASE_URL, mockCookieManager, mockTracer, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -543,6 +546,7 @@ func TestHandleCreateFlowWithSessionFailOnAcceptLoginRequest(t *testing.T) {
 	req.URL.RawQuery = values.Encode()
 
 	mockService.EXPECT().CheckSession(gomock.Any(), req.Cookies()).Return(session, nil, nil)
+	mockTracer.EXPECT().Start(gomock.Any(), "kratos.API.shouldEnforceVerificationWithSession").Return(context.Background(), trace.SpanFromContext(context.Background())).AnyTimes()
 	mockTracer.EXPECT().Start(gomock.Any(), "kratos.API.shouldEnforceMFAWithSession").Return(context.Background(), trace.SpanFromContext(context.Background())).AnyTimes()
 	mockTracer.EXPECT().Start(gomock.Any(), "kratos.API.shouldEnforceWebAuthnWithSession").Return(context.Background(), trace.SpanFromContext(context.Background())).AnyTimes()
 	mockService.EXPECT().MustReAuthenticate(gomock.Any(), loginChallenge, session, FlowStateCookie{}).Return(false, nil)
@@ -552,7 +556,7 @@ func TestHandleCreateFlowWithSessionFailOnAcceptLoginRequest(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, false, false, BASE_URL, mockCookieManager, mockTracer, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, false, false, false, BASE_URL, mockCookieManager, mockTracer, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -560,6 +564,115 @@ func TestHandleCreateFlowWithSessionFailOnAcceptLoginRequest(t *testing.T) {
 
 	if res.StatusCode != http.StatusInternalServerError {
 		t.Fatal("Expected HTTP status code 500, got: ", res.Status)
+	}
+}
+
+func TestHandleCreateFlowRedirectToVerification(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := NewMockLoggerInterface(ctrl)
+	mockService := NewMockServiceInterface(ctrl)
+	mockCookieManager := NewMockAuthCookieManagerInterface(ctrl)
+	mockTracer := NewMockTracingInterface(ctrl)
+
+	loginChallenge := "login_challenge_2341235123231"
+	identityId := "test"
+	unverifiedEmail := "unverified@example.com"
+
+	session := kClient.NewSession(identityId)
+	session.Identity = kClient.NewIdentity(identityId, "test.json", "https://test.com/test.json", map[string]string{"name": "name"})
+
+	req := httptest.NewRequest(http.MethodGet, HANDLE_CREATE_FLOW_URL, nil)
+	values := req.URL.Query()
+	values.Add("login_challenge", loginChallenge)
+	req.URL.RawQuery = values.Encode()
+
+	mockService.EXPECT().CheckSession(gomock.Any(), gomock.Any()).Return(session, nil, nil).AnyTimes()
+	mockTracer.EXPECT().Start(gomock.Any(), "kratos.API.shouldEnforceVerification").Return(context.Background(), trace.SpanFromContext(context.Background())).AnyTimes()
+	mockService.EXPECT().RequireVerificationForEmail(gomock.Any(), gomock.Any()).Return(true, unverifiedEmail, nil).Times(1)
+	mockCookieManager.EXPECT().SetStateCookie(gomock.Any(), gomock.Any()).Return(nil)
+	mockTracer.EXPECT().Start(gomock.Any(), gomock.Any()).Return(context.Background(), trace.SpanFromContext(context.Background())).AnyTimes()
+
+	w := httptest.NewRecorder()
+	mux := chi.NewMux()
+	NewAPI(mockService, true, false, true, BASE_URL, mockCookieManager, mockTracer, mockLogger).RegisterEndpoints(mux)
+
+	mux.ServeHTTP(w, req)
+
+	res := w.Result()
+	defer res.Body.Close()
+	data, err := io.ReadAll(res.Body)
+	if err != nil {
+		t.Errorf("expected error to be nil got %v", err)
+	}
+
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("expected HTTP status code 200 got %v", res.StatusCode)
+	}
+
+	loginFlow := BrowserLocationChangeRequired{}
+	if err := json.Unmarshal(data, &loginFlow); err != nil {
+		t.Errorf("expected error to be nil got %v", err)
+	}
+
+	if loginFlow.RedirectTo == nil || !strings.Contains(*loginFlow.RedirectTo, "verification") {
+		t.Errorf("expected redirect_to to contain verification path, got %v", *loginFlow.RedirectTo)
+	}
+
+	encodedEmail := url.QueryEscape(unverifiedEmail)
+	if !strings.Contains(*loginFlow.RedirectTo, encodedEmail) {
+		t.Errorf("expected redirect_to to contain the unverified email param '%s', got %v", encodedEmail, *loginFlow.RedirectTo)
+	}
+}
+
+func TestHandleCreateFlowRequireVerificationError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := NewMockLoggerInterface(ctrl)
+	mockService := NewMockServiceInterface(ctrl)
+	mockCookieManager := NewMockAuthCookieManagerInterface(ctrl)
+	mockTracer := NewMockTracingInterface(ctrl)
+
+	loginChallenge := "login_challenge_2341235123231"
+	identityId := "test"
+
+	session := kClient.NewSession(identityId)
+	session.Identity = kClient.NewIdentity(identityId, "test.json", "https://test.com/test.json", map[string]string{"name": "name"})
+
+	req := httptest.NewRequest(http.MethodGet, HANDLE_CREATE_FLOW_URL, nil)
+	values := req.URL.Query()
+	values.Add("login_challenge", loginChallenge)
+	req.URL.RawQuery = values.Encode()
+
+	mockService.EXPECT().CheckSession(gomock.Any(), gomock.Any()).Return(session, nil, nil).AnyTimes()
+	mockService.EXPECT().RequireVerificationForEmail(gomock.Any(), gomock.Any()).Return(false, "", fmt.Errorf("failed check for verification")).Times(1)
+	mockLogger.EXPECT().Debugf(gomock.Any(), gomock.Any()).AnyTimes()
+	mockLogger.EXPECT().Errorf(gomock.Any(), gomock.Any()).AnyTimes()
+
+	mockTracer.EXPECT().Start(gomock.Any(), gomock.Any()).Return(context.Background(), trace.SpanFromContext(context.Background())).AnyTimes()
+
+	w := httptest.NewRecorder()
+	mux := chi.NewMux()
+	NewAPI(mockService, true, false, true, BASE_URL, mockCookieManager, mockTracer, mockLogger).RegisterEndpoints(mux)
+
+	mux.ServeHTTP(w, req)
+
+	res := w.Result()
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("expected HTTP status code %v got %v", http.StatusInternalServerError, res.StatusCode)
+	}
+
+	data, err := io.ReadAll(res.Body)
+	if err != nil {
+		t.Errorf("expected error to be nil got %v", err)
+	}
+	
+	if !strings.Contains(string(data), "Failed check for verification") {
+		t.Errorf("expected response body to contain failure message, got %s", string(data))
 	}
 }
 
@@ -586,7 +699,7 @@ func TestHandleGetLoginFlow(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, false, false, BASE_URL, mockCookieManager, mockTracer, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, false, false, false, BASE_URL, mockCookieManager, mockTracer, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -632,7 +745,7 @@ func TestHandleGetLoginFlowFail(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, false, false, BASE_URL, mockCookieManager, mockTracer, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, false, false, false, BASE_URL, mockCookieManager, mockTracer, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -652,7 +765,7 @@ func TestHandleCreateRegistrationFlow(t *testing.T) {
     mockCookieManager := NewMockAuthCookieManagerInterface(ctrl)
     mockTracer := NewMockTracingInterface(ctrl)
 
-    api := NewAPI(mockService, false, false, BASE_URL, mockCookieManager, mockTracer, mockLogger)
+    api := NewAPI(mockService, false, false, false, BASE_URL, mockCookieManager, mockTracer, mockLogger)
 
     t.Run("service.CreateBrowserRegistrationFlow returns error", func(t *testing.T) {
         req := httptest.NewRequest(http.MethodGet, "/registration/create?return_to=/error", nil)
@@ -768,7 +881,7 @@ func TestHandleGetRegistrationFlow(t *testing.T) {
     mockCookieManager := NewMockAuthCookieManagerInterface(ctrl)
     mockTracer := NewMockTracingInterface(ctrl)
 
-    api := NewAPI(mockService, false, false, BASE_URL, mockCookieManager, mockTracer, mockLogger)
+    api := NewAPI(mockService, false, false, false, BASE_URL, mockCookieManager, mockTracer, mockLogger)
 
     t.Run("Missing id parameter", func(t *testing.T) {
         req := httptest.NewRequest(http.MethodGet, "/registration", nil)
@@ -869,7 +982,7 @@ func TestHandleUpdateRegistrationFlow(t *testing.T) {
     mockCookieManager := NewMockAuthCookieManagerInterface(ctrl)
     mockTracer := NewMockTracingInterface(ctrl)
 
-    api := NewAPI(mockService, false, false, BASE_URL, mockCookieManager, mockTracer, mockLogger)
+    api := NewAPI(mockService, false, false, false, BASE_URL, mockCookieManager, mockTracer, mockLogger)
 
     t.Run("ParseRegistrationFlowMethodBody returns error", func(t *testing.T) {
         req := httptest.NewRequest(http.MethodPost, "/registration/update?flow=e2c802141dc51a06676974687562", nil)
@@ -987,7 +1100,7 @@ func TestHandleUpdateIdentifierFirstFlow(t *testing.T) {
 	mockService.EXPECT().UpdateIdentifierFirstLoginFlow(gomock.Any(), flowId, *flowBody, req.Cookies()).Return(redirectFlow, req.Cookies(), nil)
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, false, false, BASE_URL, mockCookieManager, mockTracer, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, false, false, false, BASE_URL, mockCookieManager, mockTracer, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -1034,7 +1147,7 @@ func TestHandleUpdateIdentifierFirstFlowFailOnParseLoginFlowMethodBody(t *testin
 
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, false, false, BASE_URL, mockCookieManager, mockTracer, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, false, false, false, BASE_URL, mockCookieManager, mockTracer, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -1072,7 +1185,7 @@ func TestHandleUpdateIdentifierFirstFlowFailOnUpdateIdLoginFlow(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, false, false, BASE_URL, mockCookieManager, mockTracer, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, false, false, false, BASE_URL, mockCookieManager, mockTracer, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -1108,6 +1221,7 @@ func TestHandleUpdateFlow(t *testing.T) {
 	values.Add("flow", flowId)
 	req.URL.RawQuery = values.Encode()
 
+	mockTracer.EXPECT().Start(gomock.Any(), "kratos.API.shouldEnforceVerification").Return(context.Background(), trace.SpanFromContext(context.Background())).AnyTimes()
 	mockTracer.EXPECT().Start(gomock.Any(), "kratos.API.shouldEnforceMFA").Return(context.Background(), trace.SpanFromContext(context.Background())).AnyTimes()
 	mockTracer.EXPECT().Start(gomock.Any(), "kratos.API.shouldRegenerateBackupCodes").Return(context.Background(), trace.SpanFromContext(context.Background())).AnyTimes()
 	mockCookieManager.EXPECT().SetStateCookie(gomock.Any(), gomock.Any()).Return(nil)
@@ -1118,7 +1232,7 @@ func TestHandleUpdateFlow(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, false, false, BASE_URL, mockCookieManager, mockTracer, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, false, false, false, BASE_URL, mockCookieManager, mockTracer, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -1168,7 +1282,7 @@ func TestHandleUpdateFlowWhenProviderNotAllowed(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, false, false, BASE_URL, mockCookieManager, mockTracer, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, false, false, false, BASE_URL, mockCookieManager, mockTracer, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -1203,7 +1317,7 @@ func TestHandleUpdateFlowFailOnParseLoginFlowMethodBody(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, false, false, BASE_URL, mockCookieManager, mockTracer, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, false, false, false, BASE_URL, mockCookieManager, mockTracer, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -1257,6 +1371,7 @@ func TestHandleUpdateLoginFlowRedirectToRegenerateBackupCodes(t *testing.T) {
 	mockService.EXPECT().CheckAllowedProvider(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil)
 	mockService.EXPECT().UpdateLoginFlow(gomock.Any(), flowId, *flowBody, req.Cookies()).Return(redirectFlow, nil, req.Cookies(), nil)
 
+	mockTracer.EXPECT().Start(gomock.Any(), "kratos.API.shouldEnforceVerification").Return(context.Background(), trace.SpanFromContext(context.Background())).AnyTimes()
 	mockTracer.EXPECT().Start(gomock.Any(), "kratos.API.shouldEnforceMFA").Return(context.Background(), trace.SpanFromContext(context.Background())).AnyTimes()
 	mockService.EXPECT().CheckSession(gomock.Any(), req.Cookies()).Return(session, nil, nil)
 	mockTracer.EXPECT().Start(gomock.Any(), "kratos.API.shouldEnforceMFAWithSession").Return(context.Background(), trace.SpanFromContext(context.Background())).AnyTimes()
@@ -1270,7 +1385,7 @@ func TestHandleUpdateLoginFlowRedirectToRegenerateBackupCodes(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, true, true, BASE_URL, mockCookieManager, mockTracer, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, false, true, true, BASE_URL, mockCookieManager, mockTracer, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -1313,7 +1428,7 @@ func TestHandleUpdateFlowFailOnUpdateOIDCLoginFlow(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, false, false, BASE_URL, mockCookieManager, mockTracer, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, false, false, false, BASE_URL, mockCookieManager, mockTracer, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -1352,7 +1467,7 @@ func TestHandleUpdateFlowFailOnCheckAllowedProvider(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, false, false, BASE_URL, mockCookieManager, mockTracer, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, false, false, false, BASE_URL, mockCookieManager, mockTracer, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -1360,6 +1475,131 @@ func TestHandleUpdateFlowFailOnCheckAllowedProvider(t *testing.T) {
 
 	if res.StatusCode != http.StatusInternalServerError {
 		t.Fatal("Expected HTTP status code 500, got: ", res.Status)
+	}
+}
+
+func TestHandleUpdateFlowRedirectToVerification(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := NewMockLoggerInterface(ctrl)
+	mockService := NewMockServiceInterface(ctrl)
+	mockCookieManager := NewMockAuthCookieManagerInterface(ctrl)
+	mockTracer := NewMockTracingInterface(ctrl)
+
+	flowId := "test"
+	identityId := "test"
+	unverifiedEmail := "unverified@example.com"
+	
+	flow := kClient.NewLoginFlowWithDefaults()
+	flow.Id = flowId
+	returnToUrl := "https://some/return/url"
+	flow.ReturnTo = &returnToUrl
+
+	flowBody := new(kClient.UpdateLoginFlowBody)
+	flowBody.UpdateLoginFlowWithPasswordMethod = kClient.NewUpdateLoginFlowWithPasswordMethod(identityId, "password", "password")
+
+	session := kClient.NewSession(identityId)
+
+	req := httptest.NewRequest(http.MethodPost, HANDLE_UPDATE_LOGIN_FLOW_URL, nil)
+	values := req.URL.Query()
+	values.Add("flow", flowId)
+	req.URL.RawQuery = values.Encode()
+
+	mockService.EXPECT().ParseLoginFlowMethodBody(gomock.Any()).Return(flowBody, req.Cookies(), nil)
+	mockService.EXPECT().GetLoginFlow(gomock.Any(), flowId, req.Cookies()).Return(flow, nil, nil)
+	mockService.EXPECT().CheckAllowedProvider(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil)
+	mockService.EXPECT().UpdateLoginFlow(gomock.Any(), flowId, *flowBody, req.Cookies()).Return(nil, nil, req.Cookies(), nil)
+	mockService.EXPECT().CheckSession(gomock.Any(), req.Cookies()).Return(session, nil, nil)
+	mockService.EXPECT().RequireVerificationForEmail(gomock.Any(), session).Return(true, unverifiedEmail, nil).Times(1)
+	mockCookieManager.EXPECT().SetStateCookie(gomock.Any(), gomock.Any()).Return(nil)
+	mockTracer.EXPECT().Start(gomock.Any(), gomock.Any()).Return(context.Background(), trace.SpanFromContext(context.Background())).AnyTimes()
+	mockLogger.EXPECT().Debugf(gomock.Any(), gomock.Any()).AnyTimes()
+
+	w := httptest.NewRecorder()
+	mux := chi.NewMux()
+	NewAPI(mockService, true, false, false, BASE_URL, mockCookieManager, mockTracer, mockLogger).RegisterEndpoints(mux)
+
+	mux.ServeHTTP(w, req)
+
+	res := w.Result()
+	defer res.Body.Close()
+	data, err := io.ReadAll(res.Body)
+	if err != nil {
+		t.Errorf("expected error to be nil got %v", err)
+	}
+
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("expected HTTP status code 200 got %v", res.StatusCode)
+	}
+	
+	loginFlow := BrowserLocationChangeRequired{}
+	if err := json.Unmarshal(data, &loginFlow); err != nil {
+		t.Errorf("expected error to be nil got %v", err)
+	}
+
+	if loginFlow.RedirectTo == nil || !strings.Contains(*loginFlow.RedirectTo, "verification") {
+		t.Errorf("expected redirect_to to contain verification path, got %v", *loginFlow.RedirectTo)
+	}
+}
+
+func TestHandleUpdateFlowRequireVerificationError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := NewMockLoggerInterface(ctrl)
+	mockService := NewMockServiceInterface(ctrl)
+	mockCookieManager := NewMockAuthCookieManagerInterface(ctrl)
+	mockTracer := NewMockTracingInterface(ctrl)
+
+	flowId := "test"
+	identityId := "test"
+
+	flow := kClient.NewLoginFlowWithDefaults()
+	flow.Id = flowId
+	returnToUrl := "https://some/return/url"
+	flow.ReturnTo = &returnToUrl
+
+	flowBody := new(kClient.UpdateLoginFlowBody)
+	flowBody.UpdateLoginFlowWithPasswordMethod = kClient.NewUpdateLoginFlowWithPasswordMethod(identityId, "password", "password")
+
+	session := kClient.NewSession(identityId)
+
+	req := httptest.NewRequest(http.MethodPost, HANDLE_UPDATE_LOGIN_FLOW_URL, nil)
+	values := req.URL.Query()
+	values.Add("flow", flowId)
+	req.URL.RawQuery = values.Encode()
+
+	mockService.EXPECT().ParseLoginFlowMethodBody(gomock.Any()).Return(flowBody, req.Cookies(), nil)
+	mockService.EXPECT().GetLoginFlow(gomock.Any(), flowId, req.Cookies()).Return(flow, nil, nil)
+	mockService.EXPECT().CheckAllowedProvider(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil)
+	mockService.EXPECT().UpdateLoginFlow(gomock.Any(), flowId, *flowBody, req.Cookies()).Return(nil, nil, req.Cookies(), nil)
+	mockService.EXPECT().CheckSession(gomock.Any(), req.Cookies()).Return(session, nil, nil)
+	mockService.EXPECT().RequireVerificationForEmail(gomock.Any(), session).Return(false, "", fmt.Errorf("verification enforce check error")).Times(1)
+	mockLogger.EXPECT().Debugf(gomock.Any(), gomock.Any()).AnyTimes()
+	mockLogger.EXPECT().Error(gomock.Any()).AnyTimes()
+	mockTracer.EXPECT().Start(gomock.Any(), gomock.Any()).Return(context.Background(), trace.SpanFromContext(context.Background())).AnyTimes()
+
+	w := httptest.NewRecorder()
+	mux := chi.NewMux()
+	NewAPI(mockService, true, false, false, BASE_URL, mockCookieManager, mockTracer, mockLogger).RegisterEndpoints(mux)
+
+	mux.ServeHTTP(w, req)
+
+	res := w.Result()
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("expected HTTP status code %v got %v", http.StatusInternalServerError, res.StatusCode)
+	}
+
+	data, err := io.ReadAll(res.Body)
+	if err != nil {
+		t.Errorf("expected error to be nil got %v", err)
+	}
+
+	if !strings.Contains(string(data), "server error") && !strings.Contains(string(data), "verification enforce check error") {
+		t.Errorf("expected response body to contain failure message, got %s", string(data))
 	}
 }
 
@@ -1383,7 +1623,7 @@ func TestHandleCreateRecoveryFlow(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, false, false, BASE_URL, mockCookieManager, mockTracer, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, false, false, false, BASE_URL, mockCookieManager, mockTracer, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -1426,7 +1666,7 @@ func TestHandleCreateRecoveryFlowWithSession(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, false, false, BASE_URL, mockCookieManager, mockTracer, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, false, false, false, BASE_URL, mockCookieManager, mockTracer, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -1473,7 +1713,7 @@ func TestHandleCreateRecoveryFlowFailOnCreateBrowserRecoveryFlow(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, false, false, BASE_URL, mockCookieManager, mockTracer, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, false, false, false, BASE_URL, mockCookieManager, mockTracer, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -1507,7 +1747,7 @@ func TestHandleGetRecoveryFlow(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, false, false, BASE_URL, mockCookieManager, mockTracer, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, false, false, false, BASE_URL, mockCookieManager, mockTracer, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -1553,7 +1793,7 @@ func TestHandleGetRecoveryFlowFail(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, false, false, BASE_URL, mockCookieManager, mockTracer, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, false, false, false, BASE_URL, mockCookieManager, mockTracer, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -1595,7 +1835,7 @@ func TestHandleUpdateRecoveryFlow(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, false, false, BASE_URL, mockCookieManager, mockTracer, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, false, false, false, BASE_URL, mockCookieManager, mockTracer, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -1639,7 +1879,7 @@ func TestHandleUpdateRecoveryFlowFailOnParseRecoveryFlowMethodBody(t *testing.T)
 
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, false, false, BASE_URL, mockCookieManager, mockTracer, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, false, false, false, BASE_URL, mockCookieManager, mockTracer, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -1671,7 +1911,7 @@ func TestHandleCreateSettingsFlow(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, false, false, BASE_URL, mockCookieManager, mockTracer, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, false, false, false, BASE_URL, mockCookieManager, mockTracer, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -1714,7 +1954,7 @@ func TestHandleCreateSettingsFlowWithRedirect(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, false, false, BASE_URL, mockCookieManager, mockTracer, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, false, false, false, BASE_URL, mockCookieManager, mockTracer, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -1749,7 +1989,7 @@ func TestHandleCreateSettingsFlowFailOnCreateBrowserSettingsFlow(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, false, false, BASE_URL, mockCookieManager, mockTracer, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, false, false, false, BASE_URL, mockCookieManager, mockTracer, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -1784,7 +2024,7 @@ func TestHandleGetSettingsFlow(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, false, false, BASE_URL, mockCookieManager, mockTracer, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, false, false, false, BASE_URL, mockCookieManager, mockTracer, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -1837,7 +2077,7 @@ func TestHandleGetSettingsFlowWithRedirect(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, false, false, BASE_URL, mockCookieManager, mockTracer, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, false, false, false, BASE_URL, mockCookieManager, mockTracer, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -1875,7 +2115,7 @@ func TestHandleGetSettingsFlowFail(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, false, false, BASE_URL, mockCookieManager, mockTracer, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, false, false, false, BASE_URL, mockCookieManager, mockTracer, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -1915,7 +2155,7 @@ func TestHandleUpdateSettingsFlow(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, false, false, BASE_URL, mockCookieManager, mockTracer, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, false, false, false, BASE_URL, mockCookieManager, mockTracer, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -1975,7 +2215,7 @@ func TestHandleUpdateSettingsFlowPrivilegedSessionRequired(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, false, false, BASE_URL, mockCookieManager, mockTracer, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, false, false, false, BASE_URL, mockCookieManager, mockTracer, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -2033,7 +2273,7 @@ func TestHandleUpdateSettingsFlowWithRedirect(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, false, false, BASE_URL, mockCookieManager, mockTracer, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, false, false, false, BASE_URL, mockCookieManager, mockTracer, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -2088,7 +2328,7 @@ func TestHandleUpdateWebAuthnSettingsFlowWithReturnTo(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, false, false, BASE_URL, mockCookieManager, mockTracer, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, false, false, false, BASE_URL, mockCookieManager, mockTracer, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -2143,7 +2383,7 @@ func TestHandleUpdateWebAuthnSettingsFlowWithoutReturnTo(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, false, false, BASE_URL, mockCookieManager, mockTracer, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, false, false, false, BASE_URL, mockCookieManager, mockTracer, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -2183,7 +2423,7 @@ func TestHandleUpdateSettingsFlowFailOnParseSettingsFlowMethodBody(t *testing.T)
 
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, false, false, BASE_URL, mockCookieManager, mockTracer, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, false, false, false, BASE_URL, mockCookieManager, mockTracer, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -2270,6 +2510,7 @@ func TestHandleCreateVerificationFlow(t *testing.T) {
             mux := chi.NewMux()
             NewAPI(
                 mockService,
+				false,
                 false,
                 false,
                 BASE_URL,
@@ -2418,6 +2659,7 @@ func TestHandleGetVerificationFlow(t *testing.T) {
             mux := chi.NewMux()
             NewAPI(
                 mockService,
+				false,
                 false,
                 false,
                 BASE_URL,
@@ -2610,6 +2852,7 @@ func TestHandleUpdateVerificationFlow(t *testing.T) {
             mux := chi.NewMux()
             NewAPI(
                 mockService,
+				false,
                 false,
                 false,
                 BASE_URL,

--- a/pkg/kratos/interfaces.go
+++ b/pkg/kratos/interfaces.go
@@ -57,6 +57,7 @@ type ServiceInterface interface {
 	HasTOTPAvailable(context.Context, string) (bool, error)
 	HasWebAuthnAvailable(context.Context, string) (bool, error)
 	HasNotEnoughLookupSecretsLeft(context.Context, string) (bool, error)
+	RequireVerificationForEmail(context.Context, *kClient.Session) (bool, string, error)
 }
 
 type AuthCookieManagerInterface interface {

--- a/pkg/kratos/service.go
+++ b/pkg/kratos/service.go
@@ -1538,6 +1538,57 @@ func (s *Service) HasNotEnoughLookupSecretsLeft(ctx context.Context, id string) 
 	return true, nil
 }
 
+func (s *Service) RequireVerificationForEmail(ctx context.Context, session *kClient.Session) (bool, string, error) {
+	ctx, span := s.tracer.Start(ctx, "kratos.Service.RequireVerificationForEmail")
+	defer span.End()
+
+	if session == nil || session.Identity == nil || session.AuthenticationMethods == nil {
+		return false, "", nil
+	}
+
+	// enforce verification only on password login
+	pwdLogin := false
+	for _, method := range session.AuthenticationMethods {
+		if method.Method != nil && *method.Method == "password" {
+			pwdLogin = true
+			break
+		}
+	}
+
+	// skip verification enforcement for other methods
+	if !pwdLogin {
+		return false, "", nil
+	}
+
+	// check verifiable addresses
+	if len(session.Identity.VerifiableAddresses) == 0 {
+		return false, "", nil
+	}
+
+	traits, ok := session.Identity.Traits.(map[string]interface{})
+	if !ok {
+		return false, "", fmt.Errorf("failed to parse identity %s traits for verification check", session.Identity.GetId())
+	}
+
+	primaryIdentifier, ok := traits["email"].(string)
+	// this should never happen as kratos requires an email trait for password login
+	if !ok || primaryIdentifier == "" {
+		return false, "", fmt.Errorf("no email trait found for identity %s", session.Identity.GetId())
+	}
+
+	for _, addr := range session.Identity.VerifiableAddresses {
+		if addr.Value == primaryIdentifier {
+			if addr.Verified {
+				return false, "", nil // the identifier is verified, no need to enforce verification
+			}
+			return true, primaryIdentifier, nil // the identifier is not verified, enforce verification
+		}
+	}
+
+	s.logger.Debugf("Identity %s logged in with an identifier that is not marked as verifiable", session.Identity.GetId())
+	return false, "", nil
+}
+
 func (s *Service) is1FAMethod(method string) bool {
 	switch method {
 	case "password", "oidc":

--- a/pkg/kratos/service_test.go
+++ b/pkg/kratos/service_test.go
@@ -3784,6 +3784,198 @@ func TestHasNotEnoughLookupSecretsLeftFailonGetIdentityExecute(t *testing.T) {
 	}
 }
 
+func TestRequireVerificationForEmail(t *testing.T) {
+	passwordMethod := "password"
+	oidcMethod := "oidc"
+
+	tests := []struct {
+		name              string
+		setupSession      func() *kClient.Session
+		expectEnforce     bool
+		expectEmail       string
+		expectError       bool
+		expectDebugLog    bool
+	}{
+		{
+			name: "Nil session returns false",
+			setupSession: func() *kClient.Session {
+				return nil
+			},
+			expectEnforce: false,
+			expectEmail:   "",
+			expectError:   false,
+		},
+		{
+			name: "OIDC login skips verification",
+			setupSession: func() *kClient.Session {
+				session := kClient.NewSession("sess-id")
+				session.AuthenticationMethods = []kClient.SessionAuthenticationMethod{
+					{Method: &oidcMethod},
+				}
+				session.Identity = kClient.NewIdentity("id", "schema", "url", nil)
+				return session
+			},
+			expectEnforce: false,
+			expectEmail:   "",
+			expectError:   false,
+		},
+		{
+			name: "No verifiable addresses skips verification",
+			setupSession: func() *kClient.Session {
+				session := kClient.NewSession("sess-id")
+				session.AuthenticationMethods = []kClient.SessionAuthenticationMethod{
+					{Method: &passwordMethod},
+				}
+				session.Identity = kClient.NewIdentity("id", "schema", "url", nil)
+				session.Identity.VerifiableAddresses = []kClient.VerifiableIdentityAddress{}
+				return session
+			},
+			expectEnforce: false,
+			expectEmail:   "",
+			expectError:   false,
+		},
+		{
+			name: "Invalid traits structure returns error",
+			setupSession: func() *kClient.Session {
+				session := kClient.NewSession("sess-id")
+				session.AuthenticationMethods = []kClient.SessionAuthenticationMethod{
+					{Method: &passwordMethod},
+				}
+				session.Identity = kClient.NewIdentity("id", "schema", "url", "not-a-map")
+				session.Identity.VerifiableAddresses = []kClient.VerifiableIdentityAddress{
+					{Value: "test@example.com", Verified: false},
+				}
+				return session
+			},
+			expectEnforce: false,
+			expectEmail:   "",
+			expectError:   true,
+		},
+		{
+			name: "Missing email trait returns error",
+			setupSession: func() *kClient.Session {
+				session := kClient.NewSession("sess-id")
+				session.AuthenticationMethods = []kClient.SessionAuthenticationMethod{
+					{Method: &passwordMethod},
+				}
+				session.Identity = kClient.NewIdentity("id", "schema", "url", map[string]interface{}{
+					"name": "Test User",
+				})
+				session.Identity.VerifiableAddresses = []kClient.VerifiableIdentityAddress{
+					{Value: "test@example.com", Verified: false},
+				}
+				return session
+			},
+			expectEnforce: false,
+			expectEmail:   "",
+			expectError:   true,
+		},
+		{
+			name: "Unverified email requires verification",
+			setupSession: func() *kClient.Session {
+				session := kClient.NewSession("sess-id")
+				session.AuthenticationMethods = []kClient.SessionAuthenticationMethod{
+					{Method: &passwordMethod},
+				}
+				session.Identity = kClient.NewIdentity("id", "schema", "url", map[string]interface{}{
+					"email": "test@example.com",
+				})
+				session.Identity.VerifiableAddresses = []kClient.VerifiableIdentityAddress{
+					{Value: "test@example.com", Verified: false},
+				}
+				return session
+			},
+			expectEnforce: true,
+			expectEmail:   "test@example.com",
+			expectError:   false,
+		},
+		{
+			name: "Verified email allows access",
+			setupSession: func() *kClient.Session {
+				session := kClient.NewSession("sess-id")
+				session.AuthenticationMethods = []kClient.SessionAuthenticationMethod{
+					{Method: &passwordMethod},
+				}
+				session.Identity = kClient.NewIdentity("id", "schema", "url", map[string]interface{}{
+					"email": "test@example.com",
+				})
+				session.Identity.VerifiableAddresses = []kClient.VerifiableIdentityAddress{
+					{Value: "test@example.com", Verified: true},
+				}
+				return session
+			},
+			expectEnforce: false,
+			expectEmail:   "",
+			expectError:   false,
+		},
+		{
+			name: "Email not in verifiable addresses skips verification with warning",
+			setupSession: func() *kClient.Session {
+				session := kClient.NewSession("sess-id")
+				session.AuthenticationMethods = []kClient.SessionAuthenticationMethod{
+					{Method: &passwordMethod},
+				}
+				session.Identity = kClient.NewIdentity("id", "schema", "url", map[string]interface{}{
+					"email": "test@example.com",
+				})
+				session.Identity.VerifiableAddresses = []kClient.VerifiableIdentityAddress{
+					{Value: "other@example.com", Verified: false}, // Mismatched verifiable address
+				}
+				return session
+			},
+			expectEnforce:  false,
+			expectEmail:    "",
+			expectError:    false,
+			expectDebugLog: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockTracer := NewMockTracingInterface(ctrl)
+			mockLogger := NewMockLoggerInterface(ctrl)
+			mockMonitor := monitoring.NewMockMonitorInterface(ctrl)
+
+			ctx := context.Background()
+			session := tt.setupSession()
+
+			mockTracer.EXPECT().
+				Start(ctx, "kratos.Service.RequireVerificationForEmail").
+				Times(1).
+				Return(ctx, trace.SpanFromContext(ctx))
+
+			if tt.expectDebugLog {
+				mockLogger.EXPECT().Debugf(gomock.Any(), gomock.Any()).Times(1)
+			}
+
+			svc := NewService(nil, nil, nil, nil, false, mockTracer, mockMonitor, mockLogger)
+
+			enforce, email, err := svc.RequireVerificationForEmail(ctx, session)
+
+			if tt.expectError {
+				if err == nil {
+					t.Fatalf("expected an error but got nil")
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("expected no error but got %v", err)
+				}
+			}
+
+			if enforce != tt.expectEnforce {
+				t.Fatalf("expected enforce to be %v, got %v", tt.expectEnforce, enforce)
+			}
+
+			if email != tt.expectEmail {
+				t.Fatalf("expected email to be '%s', got '%s'", tt.expectEmail, email)
+			}
+		})
+	}
+}
+
 func TestHasWebAuthnAvailableSuccess(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/pkg/web/router.go
+++ b/pkg/web/router.go
@@ -55,8 +55,9 @@ func WithFS(fsys fs.FS) Option {
 	}
 }
 
-func WithFlags(mfa, oidcSeq, identifierFirst bool) Option {
+func WithFlags(verification, mfa, oidcSeq, identifierFirst bool) Option {
 	return func(r *routerConfig) {
+		r.verificationEnabled = verification
 		r.mfaEnabled = mfa
 		r.oidcWebAuthnSequencingEnabled = oidcSeq
 		r.identifierFirstEnabled = identifierFirst
@@ -112,6 +113,7 @@ type routerConfig struct {
 	authzClient                   authz.AuthorizerInterface
 	cookieManager                 *kratos.AuthCookieManager
 	distFS                        fs.FS
+	verificationEnabled           bool
 	mfaEnabled                    bool
 	oidcWebAuthnSequencingEnabled bool
 	identifierFirstEnabled        bool
@@ -169,6 +171,7 @@ func registerAPIs(config *routerConfig, router *chi.Mux) {
 	kratosService := kratos.NewService(config.kratosClient, config.kratosAdminClient, config.hydraClient, config.authzClient, config.oidcWebAuthnSequencingEnabled, config.tracer, config.monitor, config.logger)
 	kratos.NewAPI(
 		kratosService,
+		config.verificationEnabled,
 		config.mfaEnabled,
 		config.oidcWebAuthnSequencingEnabled,
 		config.baseURL,

--- a/ui/pages/verification.tsx
+++ b/ui/pages/verification.tsx
@@ -45,6 +45,39 @@ const Verification: NextPage = () => {
     }, RESEND_CODE_TIMEOUT);
   };
 
+  const handleSentEmailState = (flowData: VerificationFlow) => {
+    if (
+      flowData.state === "sent_email" &&
+      flowData.ui.messages?.find((msg) => msg.type === "error") === undefined
+    ) {
+      // Check if email is sent and there is no error message
+      // If no error message, add success message and disable resend button for 60 seconds
+      const codeUiNode = flowData.ui.nodes.find(
+        isVerificationCodeInput,
+      ) as UiNode;
+      if (codeUiNode) {
+        codeUiNode.meta = {
+          ...codeUiNode.meta,
+          label: {
+            ...codeUiNode.meta.label,
+            context: {
+              ...codeUiNode.meta.label?.context,
+              afterComponent: (
+                <CountDownText
+                  initialSeconds={RESEND_CODE_TIMEOUT / 1000}
+                  wrapperText="Code sent. You can request again in "
+                  key={new Date().toISOString()}
+                />
+              ),
+            },
+          },
+        } as UiNodeMeta;
+      }
+      // Disable resend button for 60 seconds
+      disableButtonWithTimeout();
+    }
+  };
+
   const redirectToErrorPage = () => {
     const idParam = flowId ? `?id=${flowId.toString()}` : "";
     window.location.href = `./error${idParam}`;
@@ -66,36 +99,8 @@ const Verification: NextPage = () => {
                 String(verificationCode);
             }
           }
-          if (
-            data.state === "sent_email" &&
-            data.ui.messages?.find((msg) => msg.type === "error") === undefined
-          ) {
-            // Check if email is sent and there is no error message
-            // If no error message, add success message and disable resend button for 60 seconds
-            const codeUiNode = data.ui.nodes.find(
-              isVerificationCodeInput,
-            ) as UiNode;
-            if (codeUiNode) {
-              codeUiNode.meta = {
-                ...codeUiNode.meta,
-                label: {
-                  ...codeUiNode.meta.label,
-                  context: {
-                    ...codeUiNode.meta.label?.context,
-                    afterComponent: (
-                      <CountDownText
-                        initialSeconds={RESEND_CODE_TIMEOUT / 1000}
-                        wrapperText="Code sent. You can request again in "
-                        key={new Date().toISOString()}
-                      />
-                    ),
-                  },
-                },
-              } as UiNodeMeta;
-            }
-            // Disable resend button for 60 seconds
-            disableButtonWithTimeout();
-          }
+
+          handleSentEmailState(data);
           setFlowIDQueryParam(String(data.id));
           setFlow(data);
         })
@@ -129,37 +134,9 @@ const Verification: NextPage = () => {
               },
             })
             .then((updateRes) => {
-              if (
-                updateRes.data.state === "sent_email" &&
-                updateRes.data.ui.messages?.find(
-                  (msg) => msg.type === "error",
-                ) === undefined
-              ) {
-                const codeUiNode = updateRes.data.ui.nodes.find(
-                  isVerificationCodeInput,
-                ) as UiNode;
-                if (codeUiNode) {
-                  codeUiNode.meta = {
-                    ...codeUiNode.meta,
-                    label: {
-                      ...codeUiNode.meta.label,
-                      context: {
-                        ...codeUiNode.meta.label?.context,
-                        afterComponent: (
-                          <CountDownText
-                            initialSeconds={RESEND_CODE_TIMEOUT / 1000}
-                            wrapperText="Code sent. You can request again in "
-                            key={new Date().toISOString()}
-                          />
-                        ),
-                      },
-                    },
-                  } as UiNodeMeta;
-                }
-              }
+              handleSentEmailState(updateRes.data);
               setFlow(updateRes.data);
               setFlowIDQueryParam(String(updateRes.data.id));
-              disableButtonWithTimeout();
 
               // Clean up the URL
               const restQuery = { ...router.query };
@@ -225,36 +202,9 @@ const Verification: NextPage = () => {
             }
             return;
           }
-          if (
-            data.state === "sent_email" &&
-            data.ui.messages?.find((msg) => msg.type === "error") === undefined
-          ) {
-            // Check if email is sent and there is no error message
-            // If no error message, add success message and disable resend button for 60 seconds
-            const codeUiNode = data.ui.nodes.find(
-              isVerificationCodeInput,
-            ) as UiNode;
-            if (codeUiNode) {
-              codeUiNode.meta = {
-                ...codeUiNode.meta,
-                label: {
-                  ...codeUiNode.meta.label,
-                  context: {
-                    ...codeUiNode.meta.label?.context,
-                    afterComponent: (
-                      <CountDownText
-                        initialSeconds={RESEND_CODE_TIMEOUT / 1000}
-                        wrapperText="Code sent. You can request again in "
-                        key={new Date().toISOString()}
-                      />
-                    ),
-                  },
-                },
-              } as UiNodeMeta;
-            }
-            // Disable resend button for 60 seconds
-            disableButtonWithTimeout();
-          } else if (data.ui.messages?.find((msg) => msg.type === "error")) {
+
+          handleSentEmailState(data);
+          if (data.ui.messages?.find((msg) => msg.type === "error")) {
             const codeUiNode = data.ui.nodes.find(
               isVerificationCodeInput,
             ) as UiNode;

--- a/ui/pages/verification.tsx
+++ b/ui/pages/verification.tsx
@@ -30,6 +30,7 @@ const Verification: NextPage = () => {
     return_to: returnTo,
     flow: flowId,
     code: verificationCode,
+    email: queryEmail,
   } = router.query;
 
   const RESEND_CODE_TIMEOUT = 60000; // 60 seconds
@@ -109,12 +110,81 @@ const Verification: NextPage = () => {
         returnTo: returnTo ? String(returnTo) : undefined,
       })
       .then(({ data }) => {
-        setFlow(data);
-        setFlowIDQueryParam(String(data.id));
+        if (queryEmail && data.state === "choose_method") {
+          const csrfNode = data.ui.nodes.find(
+            (node) =>
+              (node.attributes as UiNodeInputAttributes).name === "csrf_token",
+          );
+          const csrfToken = csrfNode
+            ? ((csrfNode.attributes as UiNodeInputAttributes).value as string)
+            : "";
+
+          kratos
+            .updateVerificationFlow({
+              flow: data.id,
+              updateVerificationFlowBody: {
+                email: String(queryEmail),
+                method: "code",
+                csrf_token: csrfToken,
+              },
+            })
+            .then((updateRes) => {
+              if (
+                updateRes.data.state === "sent_email" &&
+                updateRes.data.ui.messages?.find(
+                  (msg) => msg.type === "error",
+                ) === undefined
+              ) {
+                const codeUiNode = updateRes.data.ui.nodes.find(
+                  isVerificationCodeInput,
+                ) as UiNode;
+                if (codeUiNode) {
+                  codeUiNode.meta = {
+                    ...codeUiNode.meta,
+                    label: {
+                      ...codeUiNode.meta.label,
+                      context: {
+                        ...codeUiNode.meta.label?.context,
+                        afterComponent: (
+                          <CountDownText
+                            initialSeconds={RESEND_CODE_TIMEOUT / 1000}
+                            wrapperText="Code sent. You can request again in "
+                            key={new Date().toISOString()}
+                          />
+                        ),
+                      },
+                    },
+                  } as UiNodeMeta;
+                }
+              }
+              setFlow(updateRes.data);
+              setFlowIDQueryParam(String(updateRes.data.id));
+              disableButtonWithTimeout();
+
+              // Clean up the URL
+              const restQuery = { ...router.query };
+              delete restQuery.email;
+              void router.replace(
+                {
+                  pathname: router.pathname,
+                  query: restQuery,
+                },
+                undefined,
+                { shallow: true },
+              );
+            })
+            .catch(() => {
+              setFlow(data);
+              setFlowIDQueryParam(String(data.id));
+            });
+        } else {
+          setFlow(data);
+          setFlowIDQueryParam(String(data.id));
+        }
       })
       .catch(handleFlowError("verification", setFlow))
       .catch(redirectToErrorPage);
-  }, [flowId, router, router.isReady, returnTo]);
+  }, [flowId, router, returnTo, queryEmail, flow, redirectToErrorPage]);
 
   const handleSubmit = useCallback(
     (values: UpdateVerificationFlowBody) => {
@@ -209,7 +279,7 @@ const Verification: NextPage = () => {
           return Promise.reject(err);
         });
     },
-    [flow],
+    [flow, returnTo, router],
   );
 
   const userEmail = useMemo(() => {
@@ -258,7 +328,7 @@ const Verification: NextPage = () => {
         }),
       },
     };
-  }, [flow, resendDisabled]);
+  }, [flow, resendDisabled, userEmail]);
 
   if (!flow) {
     return <Spinner />;
@@ -272,7 +342,7 @@ const Verification: NextPage = () => {
         </Notification>
         <Spinner
           text={`You will be redirected to ${
-            returnTo ? (returnTo as string) : "/ui/manage_details"
+            returnTo ? (returnTo as string).split("?")[0] : "/ui/manage_details"
           }`}
         />
       </PageLayout>


### PR DESCRIPTION
This PR adds optional verification enforcement on login.

- Instead of relying on the kratos post-login hook `require_verified_address`, I implemented the logic in Login UI, following the pattern of MFA enforcement.
The reason is that while Kratos has a session hook for the registration -> verification flow, it currently lacks a similar hook for the login -> verification scenario. 
When the `require_verified_address` hook blocks the login, Kratos aborts the login flow and does not mint a continuation cookie. If we attempt to resume the login flow after a successful verification, Kratos returns 400 ("No session was found for this flow. Please retry the authentication") because it lost the login context. In that case we'd have to make the user go through login again, repeating the steps that were already completed before verification.
By implementing the logic in the login handlers, we can keep the session, make the user verify, and then resume the login flow from where it was interrupted.
- Added new config `VERIFICATION_ENABLED` (defaults to false). The reason for introducing it is that enabling verification is a breaking change. An SMTP server is required to enable it, otherwise existing non-verified local users would be blocked from signing in.

## Testing
Make sure to `export VERIFICATION_ENABLED="true"` and run the local docker-compose setup. Use the `test@example.com / test` identity or create another one:
```
curl -X POST http://localhost:4434/admin/identities \
  -H "Content-Type: application/json" \
  -d '{
    "schema_id": "default",
    "traits": {
      "email": "test1@example.com",
      "name": "Test1",
      "surname": "Example"
    },
    "credentials": {
      "password": {
        "config": {
          "password": "test"
        }
      }
    }
  }'
```
Then go to the login page and sign in. If the account was not previously verified, you will be redirected to the verification screen and asked to provide a code. Upon successful verification, you will need to complete MFA setup (if enabled), and finally redirected back to the oidc app.

[Screencast from 16.03.2026 12:11:54_verify_login.webm](https://github.com/user-attachments/assets/b2f68e99-7315-46a4-9be4-85c246669430)
[Screencast from 16.03.2026 12:12:48_complete_setup.webm](https://github.com/user-attachments/assets/c5d1379e-8b6d-4287-af5e-e09f19886500)