### PR TITLE
fix: add flow error handler in register password view

### DIFF
--- a/ui/components/NodeInputEmail.tsx
+++ b/ui/components/NodeInputEmail.tsx
@@ -27,7 +27,7 @@ export const NodeInputEmail: FC<NodeInputProps> = ({
   }, []);
 
   useEffect(() => {
-    setError(upstreamError);
+    setError(getError());
   }, [upstreamError]);
 
   const getError = useCallback(() => {
@@ -48,7 +48,7 @@ export const NodeInputEmail: FC<NodeInputProps> = ({
     } else {
       submitBtn?.removeAttribute("disabled");
     }
-  }, [value, upstreamError]);
+  }, [value, upstreamError, getError]);
 
   useEffect(() => {
     const error = getError();
@@ -75,7 +75,7 @@ export const NodeInputEmail: FC<NodeInputProps> = ({
         }
       }
     },
-    [value, upstreamError, dispatchSubmit],
+    [value, upstreamError, dispatchSubmit, getError],
   );
 
   return (

--- a/ui/components/NodeInputEmail.tsx
+++ b/ui/components/NodeInputEmail.tsx
@@ -60,20 +60,23 @@ export const NodeInputEmail: FC<NodeInputProps> = ({
     }
   }, [upstreamError, value]);
 
-  const submitOnEnter = useCallback((e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === "Enter") {
-      e.preventDefault();
-      e.stopPropagation();
-      const error = getError();
-      const submitBtn =
-        document.getElementsByClassName("p-button--positive")?.[0];
-      submitBtn?.setAttribute("disabled", "");
-      setError(error);
-      if (!error) {
-        void dispatchSubmit(e, "code");
+  const submitOnEnter = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === "Enter") {
+        e.preventDefault();
+        e.stopPropagation();
+        const error = getError();
+        const submitBtn =
+          document.getElementsByClassName("p-button--positive")?.[0];
+        submitBtn?.setAttribute("disabled", "");
+        setError(error);
+        if (!error) {
+          void dispatchSubmit(e, "code");
+        }
       }
-    }
-  }, [value, upstreamError, dispatchSubmit]);
+    },
+    [value, upstreamError, dispatchSubmit],
+  );
 
   return (
     <Input

--- a/ui/components/NodeInputEmail.tsx
+++ b/ui/components/NodeInputEmail.tsx
@@ -26,6 +26,10 @@ export const NodeInputEmail: FC<NodeInputProps> = ({
     }
   }, []);
 
+  useEffect(() => {
+    setError(upstreamError);
+  }, [upstreamError]);
+
   const getError = useCallback(() => {
     const isInvalid = !emailRegex.test((value as string) ?? "") && value !== "";
     const localError = isInvalid ? "Incorrect email address" : undefined;
@@ -56,7 +60,7 @@ export const NodeInputEmail: FC<NodeInputProps> = ({
     }
   }, [upstreamError, value]);
 
-  const submitOnEnter = (e: React.KeyboardEvent<HTMLInputElement>) => {
+  const submitOnEnter = useCallback((e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === "Enter") {
       e.preventDefault();
       e.stopPropagation();
@@ -69,7 +73,7 @@ export const NodeInputEmail: FC<NodeInputProps> = ({
         void dispatchSubmit(e, "code");
       }
     }
-  };
+  }, [value, upstreamError, dispatchSubmit]);
 
   return (
     <Input

--- a/ui/components/NodeInputText.tsx
+++ b/ui/components/NodeInputText.tsx
@@ -51,7 +51,7 @@ export const NodeInputText: FC<NodeInputProps> = ({
     if (isVerificationCodeInput(node)) {
       setIsDirty(false);
     }
-  }, [node.messages]);
+  }, [node.messages, error]);
 
   const beforeComponent = (
     node.meta.label?.context as {
@@ -127,7 +127,7 @@ export const NodeInputText: FC<NodeInputProps> = ({
       return ucFirst(error);
     }
 
-    return undefined;
+    return error;
   }, [
     message,
     node.messages,

--- a/ui/components/RegisterPassword.tsx
+++ b/ui/components/RegisterPassword.tsx
@@ -26,6 +26,7 @@ export const RegisterPassword = ({ flow, setFlow }: RegisterPasswordProps) => {
   const [password, setPassword] = useState("");
   const [isPassValid, setPassValid] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [flowError, setFlowError] = useState<string | null>(null);
   const router = useRouter();
 
   const CSRFToken = useMemo(() => {
@@ -102,6 +103,13 @@ export const RegisterPassword = ({ flow, setFlow }: RegisterPasswordProps) => {
           }
           return Promise.reject(error);
         })
+        .catch((err: AxiosError<string>) => {
+          console.error("Error after handling flow error:", err);
+          setFlowError(
+            err.response?.data ||
+              "An unexpected error occurred. Please try again.",
+          );
+        })
         .finally(() => {
           setIsSubmitting(false);
         });
@@ -120,6 +128,11 @@ export const RegisterPassword = ({ flow, setFlow }: RegisterPasswordProps) => {
           isValid={isPassValid}
           setValid={setPassValid}
         />
+        {flowError && (
+          <div className="p-form-validation is-error">
+            <p className="p-form-validation__message">{flowError}</p>
+          </div>
+        )}
         <Button
           type="submit"
           appearance="positive"

--- a/ui/components/RegisterPassword.tsx
+++ b/ui/components/RegisterPassword.tsx
@@ -45,6 +45,7 @@ export const RegisterPassword = ({ flow, setFlow }: RegisterPasswordProps) => {
       if (!flow) return;
       e.preventDefault();
       setIsSubmitting(true);
+      setFlowError(null);
       const emailNode: UiNode = flow?.ui.nodes.find(
         (node: UiNode) =>
           (node.attributes as UiNodeInputAttributes).name === "traits.email",


### PR DESCRIPTION
Fixes errors not showing up in RegisterPassword page in Registration Flow

QA Steps:
Visit /ui/register
Input test@example.com as email and press next
Enter any valid password and enter the same one in the field below
Press submit
An error should show up saying that the email is already registered
Fixes https://github.com/canonical/identity-platform-login-ui/issues/860