### PR TITLE
Fix duplicate buttons in flow object

### DIFF
--- a/ui/components/Flow.tsx
+++ b/ui/components/Flow.tsx
@@ -127,11 +127,23 @@ export class Flow<T extends Values> extends Component<Props<T>, State<T>> {
     if (!flow || !flow.ui.nodes) {
       return [];
     }
-    const filteredNodes = flow.ui.nodes.filter(({ group }) => {
-      if (!only) {
-        return true;
+
+    const filteredNodes = flow.ui.nodes.filter((node) => {
+      const { group } = node;
+
+      if (only && group !== "default" && group !== only) {
+        return false;
       }
-      return group === "default" || group === only;
+
+      // Exclude buttons with label text "Back" until Kratos solves the multiple button issue
+      if (node.type === "input" && node.meta?.label?.text === "Back") {
+        const attrs = node.attributes as any;
+        if (attrs?.type === "button" || attrs?.type === "submit") {
+          return false;
+        }
+      }
+
+      return true;
     });
 
     return dedupeUiNodes(filteredNodes);

--- a/ui/components/Flow.tsx
+++ b/ui/components/Flow.tsx
@@ -50,6 +50,34 @@ interface State<T> {
   error?: string;
 }
 
+function dedupeUiNodes(nodes: UiNode[]): UiNode[] {
+  // Set keeps the order of insertion so UINodes don't get scrambled
+  const seen = new Set<string>();
+
+  return nodes.filter((node) => {
+    const attrs = node.attributes as any;
+    const attrName = attrs.name || "";
+    const attrValue = attrs.value || "";
+    const attrType = attrs.type || "";
+    const labelId = node.meta.label?.id || "";
+    const labelText = node.meta.label?.text || "";
+    const group = node.group;
+    const type = node.type;
+
+    if (attrs.type === "hidden") {
+      return true;
+    }
+
+    const key = `${group}-${type}-${attrName}-${attrValue}-${attrType}-${labelId}-${labelText}`;
+    if (seen.has(key)) {
+      return false;
+    }
+
+    seen.add(key);
+    return true;
+  });
+}
+
 export class Flow<T extends Values> extends Component<Props<T>, State<T>> {
   constructor(props: Props<T>) {
     super(props);
@@ -99,12 +127,14 @@ export class Flow<T extends Values> extends Component<Props<T>, State<T>> {
     if (!flow || !flow.ui.nodes) {
       return [];
     }
-    return flow.ui.nodes.filter(({ group }) => {
+    const filteredNodes = flow.ui.nodes.filter(({ group }) => {
       if (!only) {
         return true;
       }
       return group === "default" || group === only;
     });
+
+    return dedupeUiNodes(filteredNodes);
   };
 
   // Handles form submission


### PR DESCRIPTION
# Description
Kratos returnes multiple buttons (duplicates) in certain specific cases described in the (now hopefully) solved issue.
This approach is the less invasive before the release and allows us to remove it easily when the bug is eradicated upstream.

A backend implementation was attempted but given the nature of the Go implementation of the http layer, it would have forced us to refactor all handlers involved which I wanted to avoid.

Fixes #873 