### PR TITLE
Allow webauthn 2fa along with totp

### DIFF
--- a/pkg/kratos/handlers.go
+++ b/pkg/kratos/handlers.go
@@ -58,9 +58,9 @@ func (a *API) RegisterEndpoints(mux *chi.Mux) {
 	mux.Get("/api/kratos/self-service/registration/browser", a.handleCreateRegistrationFlow)
 	mux.Get("/api/kratos/self-service/registration/flows", a.handleGetRegistrationFlow)
 	mux.Get("/api/kratos/self-service/errors", a.handleKratosError)
-    mux.Post("/api/kratos/self-service/verification", a.handleUpdateVerificationFlow)
-    mux.Get("/api/kratos/self-service/verification/browser", a.handleCreateVerificationFlow)
-    mux.Get("/api/kratos/self-service/verification/flows", a.handleGetVerificationFlow)
+	mux.Post("/api/kratos/self-service/verification", a.handleUpdateVerificationFlow)
+	mux.Get("/api/kratos/self-service/verification/browser", a.handleCreateVerificationFlow)
+	mux.Get("/api/kratos/self-service/verification/flows", a.handleGetVerificationFlow)
 	mux.Post("/api/kratos/self-service/recovery", a.handleUpdateRecoveryFlow)
 	mux.Get("/api/kratos/self-service/recovery/browser", a.handleCreateRecoveryFlow)
 	mux.Get("/api/kratos/self-service/recovery/flows", a.handleGetRecoveryFlow)
@@ -415,18 +415,25 @@ func (a *API) handleUpdateIdentifierFirstFlow(w http.ResponseWriter, r *http.Req
 func (a *API) handleUpdateFlow(w http.ResponseWriter, r *http.Request) {
 	q := r.URL.Query()
 	flowId := q.Get("flow")
-
-	body, cookies, err := a.service.ParseLoginFlowMethodBody(r)
-	if err != nil {
-		a.logger.Errorf("Error when parsing request body: %v\n", err)
-		http.Error(w, "Failed to parse login flow", http.StatusInternalServerError)
+	if flowId == "" {
+		http.Error(w, "Missing flow ID", http.StatusBadRequest)
 		return
 	}
 
+	// Fetch the login flow first so we know the requested AAL before parsing
+	// the body. The AAL is needed to decide whether the session cookie should be
+	// stripped (1FA restart) or preserved.
 	loginFlow, _, err := a.service.GetLoginFlow(r.Context(), flowId, r.Cookies())
 	if err != nil {
 		a.logger.Errorf("Error when getting login flow: %v\n", err)
 		http.Error(w, "Failed to get login flow", http.StatusInternalServerError)
+		return
+	}
+
+	body, cookies, err := a.service.ParseLoginFlowMethodBody(r, string(loginFlow.GetRequestedAal()))
+	if err != nil {
+		a.logger.Errorf("Error when parsing request body: %v\n", err)
+		http.Error(w, "Failed to parse login flow", http.StatusInternalServerError)
 		return
 	}
 
@@ -1138,68 +1145,68 @@ func (a *API) handleCreateSettingsFlow(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *API) handleUpdateVerificationFlow(w http.ResponseWriter, r *http.Request) {
-    q := r.URL.Query()
+	q := r.URL.Query()
 
-    flowId := q.Get("flow")
-    if flowId == "" {
-        a.logger.Debug("no flow id provided")
-        http.Error(w, "no flow id provided", http.StatusBadRequest)
-        return
-    }
+	flowId := q.Get("flow")
+	if flowId == "" {
+		a.logger.Debug("no flow id provided")
+		http.Error(w, "no flow id provided", http.StatusBadRequest)
+		return
+	}
 
-    var body client.UpdateVerificationFlowBody
-    if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-        a.logger.Errorf("Error when parsing request body: %v\n", err)
-        http.Error(w, "Failed to parse verification flow", http.StatusInternalServerError)
-        return
-    }
+	var body client.UpdateVerificationFlowBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		a.logger.Errorf("Error when parsing request body: %v\n", err)
+		http.Error(w, "Failed to parse verification flow", http.StatusInternalServerError)
+		return
+	}
 
-    flow, cookies, err := a.service.UpdateVerificationFlow(r.Context(), flowId, body, r.Cookies())
-    if err != nil {
-        a.logger.Errorf("Error when updating verification flow: %v\n", err)
-        http.Error(w, err.Error(), http.StatusInternalServerError)
-        return
-    }
+	flow, cookies, err := a.service.UpdateVerificationFlow(r.Context(), flowId, body, r.Cookies())
+	if err != nil {
+		a.logger.Errorf("Error when updating verification flow: %v\n", err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
 
-    setCookies(w, cookies)
-    w.WriteHeader(http.StatusOK)
-    json.NewEncoder(w).Encode(flow)
+	setCookies(w, cookies)
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(flow)
 }
 
 func (a *API) handleCreateVerificationFlow(w http.ResponseWriter, r *http.Request) {
-    flow, cookies, err := a.service.CreateBrowserVerificationFlow(r.Context(), r.Cookies())
-    if err != nil {
-        a.logger.Errorf("Failed to create verification flow: %v\n", err)
-        http.Error(w, "Failed to create verification flow", http.StatusInternalServerError)
-        return
-    }
+	flow, cookies, err := a.service.CreateBrowserVerificationFlow(r.Context(), r.Cookies())
+	if err != nil {
+		a.logger.Errorf("Failed to create verification flow: %v\n", err)
+		http.Error(w, "Failed to create verification flow", http.StatusInternalServerError)
+		return
+	}
 
-    setCookies(w, cookies)
-    w.WriteHeader(http.StatusOK)
-    json.NewEncoder(w).Encode(flow)
+	setCookies(w, cookies)
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(flow)
 }
 
 func (a *API) handleGetVerificationFlow(w http.ResponseWriter, r *http.Request) {
-    q := r.URL.Query()
+	q := r.URL.Query()
 
-    flowId := q.Get("id")
-    if flowId == "" {
-        a.logger.Debug("no flow id provided")
-        http.Error(w, "no flow id provided", http.StatusBadRequest)
-        return
-    }
+	flowId := q.Get("id")
+	if flowId == "" {
+		a.logger.Debug("no flow id provided")
+		http.Error(w, "no flow id provided", http.StatusBadRequest)
+		return
+	}
 
-    flow, cookies, err := a.service.GetVerificationFlow(r.Context(), flowId, r.Cookies())
-    if err != nil {
-        a.logger.Errorf("Error when getting verification flow: %v\n", err)
-        http.Error(w, "Failed to get verification flow", http.StatusInternalServerError)
-        return
-    }
+	flow, cookies, err := a.service.GetVerificationFlow(r.Context(), flowId, r.Cookies())
+	if err != nil {
+		a.logger.Errorf("Error when getting verification flow: %v\n", err)
+		http.Error(w, "Failed to get verification flow", http.StatusInternalServerError)
+		return
+	}
 
-    setCookies(w, cookies)
+	setCookies(w, cookies)
 
-    w.WriteHeader(http.StatusOK)
-    json.NewEncoder(w).Encode(flow)
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(flow)
 }
 
 func (a *API) isHTMLRequest(r *http.Request) bool {

--- a/pkg/kratos/handlers.go
+++ b/pkg/kratos/handlers.go
@@ -516,17 +516,25 @@ func (a *API) handleUpdateFlow(w http.ResponseWriter, r *http.Request) {
 	q := r.URL.Query()
 	flowId := q.Get("flow")
 
-	body, httpCookies, err := a.service.ParseLoginFlowMethodBody(r)
-	if err != nil {
-		a.logger.Errorf("Error when parsing request body: %v\n", err)
-		http.Error(w, "Failed to parse login flow", http.StatusInternalServerError)
+	if flowId == "" {
+		http.Error(w, "Missing flow ID", http.StatusBadRequest)
 		return
 	}
 
+	// Fetch the login flow first so we know the requested AAL before parsing
+	// the body. The AAL is needed to decide whether the session cookie should be
+	// stripped (1FA restart) or preserved.
 	loginFlow, _, err := a.service.GetLoginFlow(r.Context(), flowId, r.Cookies())
 	if err != nil {
 		a.logger.Errorf("Error when getting login flow: %v\n", err)
 		http.Error(w, "Failed to get login flow", http.StatusInternalServerError)
+		return
+	}
+
+	body, httpCookies, err := a.service.ParseLoginFlowMethodBody(r, string(loginFlow.GetRequestedAal()))
+	if err != nil {
+		a.logger.Errorf("Error when parsing request body: %v\n", err)
+		http.Error(w, "Failed to parse login flow", http.StatusInternalServerError)
 		return
 	}
 

--- a/pkg/kratos/handlers_test.go
+++ b/pkg/kratos/handlers_test.go
@@ -1225,7 +1225,7 @@ func TestHandleUpdateFlow(t *testing.T) {
 	mockTracer.EXPECT().Start(gomock.Any(), "kratos.API.shouldEnforceMFA").Return(context.Background(), trace.SpanFromContext(context.Background())).AnyTimes()
 	mockTracer.EXPECT().Start(gomock.Any(), "kratos.API.shouldRegenerateBackupCodes").Return(context.Background(), trace.SpanFromContext(context.Background())).AnyTimes()
 	mockCookieManager.EXPECT().SetStateCookie(gomock.Any(), gomock.Any()).Return(nil)
-	mockService.EXPECT().ParseLoginFlowMethodBody(gomock.Any()).Return(flowBody, req.Cookies(), nil)
+	mockService.EXPECT().ParseLoginFlowMethodBody(gomock.Any(), gomock.Any()).Return(flowBody, req.Cookies(), nil)
 	mockService.EXPECT().UpdateLoginFlow(gomock.Any(), flowId, *flowBody, req.Cookies()).Return(redirectFlow, nil, req.Cookies(), nil)
 	mockService.EXPECT().GetLoginFlow(gomock.Any(), flowId, req.Cookies()).Return(flow, nil, nil)
 	mockService.EXPECT().CheckAllowedProvider(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil)
@@ -1276,7 +1276,7 @@ func TestHandleUpdateFlowWhenProviderNotAllowed(t *testing.T) {
 	values.Add("flow", flowId)
 	req.URL.RawQuery = values.Encode()
 
-	mockService.EXPECT().ParseLoginFlowMethodBody(gomock.Any()).Return(flowBody, req.Cookies(), nil)
+	mockService.EXPECT().ParseLoginFlowMethodBody(gomock.Any(), gomock.Any()).Return(flowBody, req.Cookies(), nil)
 	mockService.EXPECT().GetLoginFlow(gomock.Any(), flowId, req.Cookies()).Return(flow, nil, nil)
 	mockService.EXPECT().CheckAllowedProvider(gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
 
@@ -1307,12 +1307,16 @@ func TestHandleUpdateFlowFailOnParseLoginFlowMethodBody(t *testing.T) {
 	flowBody := new(kClient.UpdateLoginFlowBody)
 	flowBody.UpdateLoginFlowWithOidcMethod = kClient.NewUpdateLoginFlowWithOidcMethod("oidc", "oidc")
 
+	loginFlow := kClient.NewLoginFlowWithDefaults()
+	loginFlow.SetRequestedAal("aal1")
+
 	req := httptest.NewRequest(http.MethodPost, HANDLE_UPDATE_LOGIN_FLOW_URL, nil)
 	values := req.URL.Query()
 	values.Add("flow", flowId)
 	req.URL.RawQuery = values.Encode()
 
-	mockService.EXPECT().ParseLoginFlowMethodBody(gomock.Any()).Return(flowBody, nil, fmt.Errorf("error"))
+	mockService.EXPECT().GetLoginFlow(gomock.Any(), flowId, gomock.Any()).Return(loginFlow, nil, nil)
+	mockService.EXPECT().ParseLoginFlowMethodBody(gomock.Any(), gomock.Any()).Return(flowBody, nil, fmt.Errorf("error"))
 	mockLogger.EXPECT().Errorf(gomock.Any(), gomock.Any()).AnyTimes()
 
 	w := httptest.NewRecorder()
@@ -1366,7 +1370,7 @@ func TestHandleUpdateLoginFlowRedirectToRegenerateBackupCodes(t *testing.T) {
 	values.Add("flow", flowId)
 	req.URL.RawQuery = values.Encode()
 
-	mockService.EXPECT().ParseLoginFlowMethodBody(gomock.Any()).Return(flowBody, req.Cookies(), nil)
+	mockService.EXPECT().ParseLoginFlowMethodBody(gomock.Any(), gomock.Any()).Return(flowBody, req.Cookies(), nil)
 	mockService.EXPECT().GetLoginFlow(gomock.Any(), flowId, req.Cookies()).Return(flow, nil, nil)
 	mockService.EXPECT().CheckAllowedProvider(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil)
 	mockService.EXPECT().UpdateLoginFlow(gomock.Any(), flowId, *flowBody, req.Cookies()).Return(redirectFlow, nil, req.Cookies(), nil)
@@ -1420,7 +1424,7 @@ func TestHandleUpdateFlowFailOnUpdateOIDCLoginFlow(t *testing.T) {
 	values.Add("flow", flowId)
 	req.URL.RawQuery = values.Encode()
 
-	mockService.EXPECT().ParseLoginFlowMethodBody(gomock.Any()).Return(flowBody, req.Cookies(), nil)
+	mockService.EXPECT().ParseLoginFlowMethodBody(gomock.Any(), gomock.Any()).Return(flowBody, req.Cookies(), nil)
 	mockService.EXPECT().UpdateLoginFlow(gomock.Any(), flowId, *flowBody, req.Cookies()).Return(nil, nil, nil, fmt.Errorf("error"))
 	mockService.EXPECT().GetLoginFlow(gomock.Any(), flowId, req.Cookies()).Return(flow, nil, nil)
 	mockService.EXPECT().CheckAllowedProvider(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil)
@@ -1460,7 +1464,7 @@ func TestHandleUpdateFlowFailOnCheckAllowedProvider(t *testing.T) {
 	values.Add("flow", flowId)
 	req.URL.RawQuery = values.Encode()
 
-	mockService.EXPECT().ParseLoginFlowMethodBody(gomock.Any()).Return(flowBody, req.Cookies(), nil)
+	mockService.EXPECT().ParseLoginFlowMethodBody(gomock.Any(), gomock.Any()).Return(flowBody, req.Cookies(), nil)
 	mockService.EXPECT().GetLoginFlow(gomock.Any(), flowId, req.Cookies()).Return(flow, nil, nil)
 	mockService.EXPECT().CheckAllowedProvider(gomock.Any(), gomock.Any(), gomock.Any()).Return(false, fmt.Errorf("error"))
 	mockLogger.EXPECT().Errorf(gomock.Any(), gomock.Any()).AnyTimes()
@@ -1506,7 +1510,7 @@ func TestHandleUpdateFlowRedirectToVerification(t *testing.T) {
 	values.Add("flow", flowId)
 	req.URL.RawQuery = values.Encode()
 
-	mockService.EXPECT().ParseLoginFlowMethodBody(gomock.Any()).Return(flowBody, req.Cookies(), nil)
+	mockService.EXPECT().ParseLoginFlowMethodBody(gomock.Any(), gomock.Any()).Return(flowBody, req.Cookies(), nil)
 	mockService.EXPECT().GetLoginFlow(gomock.Any(), flowId, req.Cookies()).Return(flow, nil, nil)
 	mockService.EXPECT().CheckAllowedProvider(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil)
 	mockService.EXPECT().UpdateLoginFlow(gomock.Any(), flowId, *flowBody, req.Cookies()).Return(nil, nil, req.Cookies(), nil)
@@ -1570,7 +1574,7 @@ func TestHandleUpdateFlowRequireVerificationError(t *testing.T) {
 	values.Add("flow", flowId)
 	req.URL.RawQuery = values.Encode()
 
-	mockService.EXPECT().ParseLoginFlowMethodBody(gomock.Any()).Return(flowBody, req.Cookies(), nil)
+	mockService.EXPECT().ParseLoginFlowMethodBody(gomock.Any(), gomock.Any()).Return(flowBody, req.Cookies(), nil)
 	mockService.EXPECT().GetLoginFlow(gomock.Any(), flowId, req.Cookies()).Return(flow, nil, nil)
 	mockService.EXPECT().CheckAllowedProvider(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil)
 	mockService.EXPECT().UpdateLoginFlow(gomock.Any(), flowId, *flowBody, req.Cookies()).Return(nil, nil, req.Cookies(), nil)

--- a/pkg/kratos/handlers_test.go
+++ b/pkg/kratos/handlers_test.go
@@ -35,9 +35,9 @@ const (
 	HANDLE_CREATE_SETTINGS_FLOW_URL               = BASE_URL + "/api/kratos/self-service/settings/browser"
 	HANDLE_UPDATE_SETTINGS_FLOW_URL               = BASE_URL + "/api/kratos/self-service/settings"
 	HANDLE_GET_SETTINGS_FLOW_URL                  = BASE_URL + "/api/kratos/self-service/settings/flows"
-    HANDLE_CREATE_VERIFICATION_FLOW_URL = BASE_URL + "/api/kratos/self-service/verification/browser"
-    HANDLE_UPDATE_VERIFICATION_FLOW_URL = BASE_URL + "/api/kratos/self-service/verification"
-    HANDLE_GET_VERIFICATION_FLOW_URL = BASE_URL + "/api/kratos/self-service/verification/flows"
+	HANDLE_CREATE_VERIFICATION_FLOW_URL           = BASE_URL + "/api/kratos/self-service/verification/browser"
+	HANDLE_UPDATE_VERIFICATION_FLOW_URL           = BASE_URL + "/api/kratos/self-service/verification"
+	HANDLE_GET_VERIFICATION_FLOW_URL              = BASE_URL + "/api/kratos/self-service/verification/flows"
 )
 
 //go:generate mockgen -build_flags=--mod=mod -package kratos -destination ./mock_logger.go -source=../../internal/logging/interfaces.go
@@ -670,7 +670,7 @@ func TestHandleCreateFlowRequireVerificationError(t *testing.T) {
 	if err != nil {
 		t.Errorf("expected error to be nil got %v", err)
 	}
-	
+
 	if !strings.Contains(string(data), "Failed check for verification") {
 		t.Errorf("expected response body to contain failure message, got %s", string(data))
 	}
@@ -757,320 +757,317 @@ func TestHandleGetLoginFlowFail(t *testing.T) {
 }
 
 func TestHandleCreateRegistrationFlow(t *testing.T) {
-    ctrl := gomock.NewController(t)
-    defer ctrl.Finish()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
 
-    mockLogger := NewMockLoggerInterface(ctrl)
-    mockService := NewMockServiceInterface(ctrl)
-    mockCookieManager := NewMockAuthCookieManagerInterface(ctrl)
-    mockTracer := NewMockTracingInterface(ctrl)
+	mockLogger := NewMockLoggerInterface(ctrl)
+	mockService := NewMockServiceInterface(ctrl)
+	mockCookieManager := NewMockAuthCookieManagerInterface(ctrl)
+	mockTracer := NewMockTracingInterface(ctrl)
 
-    api := NewAPI(mockService, false, false, false, BASE_URL, mockCookieManager, mockTracer, mockLogger)
+	api := NewAPI(mockService, false, false, false, BASE_URL, mockCookieManager, mockTracer, mockLogger)
 
-    t.Run("service.CreateBrowserRegistrationFlow returns error", func(t *testing.T) {
-        req := httptest.NewRequest(http.MethodGet, "/registration/create?return_to=/error", nil)
-        w := httptest.NewRecorder()
+	t.Run("service.CreateBrowserRegistrationFlow returns error", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/registration/create?return_to=/error", nil)
+		w := httptest.NewRecorder()
 
-        mockService.EXPECT().CreateBrowserRegistrationFlow(gomock.Any(), "/error").
-            Return(nil, nil, errors.New("create failed"))
-        mockLogger.EXPECT().Errorf("Failed to create registration flow: %v", gomock.Any())
+		mockService.EXPECT().CreateBrowserRegistrationFlow(gomock.Any(), "/error").
+			Return(nil, nil, errors.New("create failed"))
+		mockLogger.EXPECT().Errorf("Failed to create registration flow: %v", gomock.Any())
 
-        api.handleCreateRegistrationFlow(w, req)
+		api.handleCreateRegistrationFlow(w, req)
 
-        res := w.Result()
-        defer res.Body.Close()
+		res := w.Result()
+		defer res.Body.Close()
 
-        if res.StatusCode != http.StatusInternalServerError {
-            t.Fatalf("expected %d, got %d", http.StatusInternalServerError, res.StatusCode)
-        }
+		if res.StatusCode != http.StatusInternalServerError {
+			t.Fatalf("expected %d, got %d", http.StatusInternalServerError, res.StatusCode)
+		}
 
-        data, _ := io.ReadAll(res.Body)
-        if !strings.Contains(string(data), "Failed to create registration flow") {
-            t.Fatalf("expected failure message, got %q", string(data))
-        }
-    })
+		data, _ := io.ReadAll(res.Body)
+		if !strings.Contains(string(data), "Failed to create registration flow") {
+			t.Fatalf("expected failure message, got %q", string(data))
+		}
+	})
 
-    t.Run("success - custom return_to", func(t *testing.T) {
-        flowID := "flow-abc-123"
-        req := httptest.NewRequest(http.MethodGet, "/registration/create?return_to=/welcome", nil)
-        w := httptest.NewRecorder()
+	t.Run("success - custom return_to", func(t *testing.T) {
+		flowID := "flow-abc-123"
+		req := httptest.NewRequest(http.MethodGet, "/registration/create?return_to=/welcome", nil)
+		w := httptest.NewRecorder()
 
-        flow := kClient.NewRegistrationFlowWithDefaults()
-        flow.SetId(flowID)
-        cookies := []*http.Cookie{{Name: "session", Value: "xyz"}}
+		flow := kClient.NewRegistrationFlowWithDefaults()
+		flow.SetId(flowID)
+		cookies := []*http.Cookie{{Name: "session", Value: "xyz"}}
 
-        mockService.EXPECT().CreateBrowserRegistrationFlow(gomock.Any(), "/welcome").
-            Return(flow, cookies, nil)
+		mockService.EXPECT().CreateBrowserRegistrationFlow(gomock.Any(), "/welcome").
+			Return(flow, cookies, nil)
 
-        api.handleCreateRegistrationFlow(w, req)
+		api.handleCreateRegistrationFlow(w, req)
 
-        res := w.Result()
-        defer res.Body.Close()
+		res := w.Result()
+		defer res.Body.Close()
 
-        if res.StatusCode != http.StatusOK {
-            t.Fatalf("expected %d, got %d", http.StatusOK, res.StatusCode)
-        }
+		if res.StatusCode != http.StatusOK {
+			t.Fatalf("expected %d, got %d", http.StatusOK, res.StatusCode)
+		}
 
-        foundCookie := false
-        for _, c := range res.Cookies() {
-            if c.Name == "session" && c.Value == "xyz" {
-                foundCookie = true
-            }
-        }
-        if !foundCookie {
-            t.Fatalf("expected cookie 'session=xyz' to be set")
-        }
+		foundCookie := false
+		for _, c := range res.Cookies() {
+			if c.Name == "session" && c.Value == "xyz" {
+				foundCookie = true
+			}
+		}
+		if !foundCookie {
+			t.Fatalf("expected cookie 'session=xyz' to be set")
+		}
 
-        var body map[string]interface{}
-        if err := json.NewDecoder(res.Body).Decode(&body); err != nil {
-            t.Fatalf("unexpected decode error: %v", err)
-        }
-        if body["id"] != flowID {
-            t.Fatalf("expected id %s, got %v", flowID, body["id"])
-        }
-    })
+		var body map[string]interface{}
+		if err := json.NewDecoder(res.Body).Decode(&body); err != nil {
+			t.Fatalf("unexpected decode error: %v", err)
+		}
+		if body["id"] != flowID {
+			t.Fatalf("expected id %s, got %v", flowID, body["id"])
+		}
+	})
 
-    t.Run("success - no return_to", func(t *testing.T) {
-        flowID := "flow-789"
-        req := httptest.NewRequest(http.MethodGet, "/registration/create", nil)
-        w := httptest.NewRecorder()
+	t.Run("success - no return_to", func(t *testing.T) {
+		flowID := "flow-789"
+		req := httptest.NewRequest(http.MethodGet, "/registration/create", nil)
+		w := httptest.NewRecorder()
 
-        flow := kClient.NewRegistrationFlowWithDefaults()
-        flow.SetId(flowID)
-        cookies := []*http.Cookie{{Name: "def", Value: "ok"}}
+		flow := kClient.NewRegistrationFlowWithDefaults()
+		flow.SetId(flowID)
+		cookies := []*http.Cookie{{Name: "def", Value: "ok"}}
 
-        mockService.EXPECT().CreateBrowserRegistrationFlow(gomock.Any(), "").
-            Return(flow, cookies, nil)
+		mockService.EXPECT().CreateBrowserRegistrationFlow(gomock.Any(), "").
+			Return(flow, cookies, nil)
 
-        api.handleCreateRegistrationFlow(w, req)
+		api.handleCreateRegistrationFlow(w, req)
 
-        res := w.Result()
-        defer res.Body.Close()
+		res := w.Result()
+		defer res.Body.Close()
 
-        if res.StatusCode != http.StatusOK {
-            t.Fatalf("expected %d, got %d", http.StatusOK, res.StatusCode)
-        }
+		if res.StatusCode != http.StatusOK {
+			t.Fatalf("expected %d, got %d", http.StatusOK, res.StatusCode)
+		}
 
-        foundCookie := false
-        for _, c := range res.Cookies() {
-            if c.Name == "def" && c.Value == "ok" {
-                foundCookie = true
-            }
-        }
-        if !foundCookie {
-            t.Fatalf("expected cookie 'def=ok' to be set")
-        }
+		foundCookie := false
+		for _, c := range res.Cookies() {
+			if c.Name == "def" && c.Value == "ok" {
+				foundCookie = true
+			}
+		}
+		if !foundCookie {
+			t.Fatalf("expected cookie 'def=ok' to be set")
+		}
 
-        var body map[string]interface{}
-        if err := json.NewDecoder(res.Body).Decode(&body); err != nil {
-            t.Fatalf("unexpected decode error: %v", err)
-        }
-        if body["id"] != flowID {
-            t.Fatalf("expected id %s, got %v", flowID, body["id"])
-        }
-    })
+		var body map[string]interface{}
+		if err := json.NewDecoder(res.Body).Decode(&body); err != nil {
+			t.Fatalf("unexpected decode error: %v", err)
+		}
+		if body["id"] != flowID {
+			t.Fatalf("expected id %s, got %v", flowID, body["id"])
+		}
+	})
 }
 
-
 func TestHandleGetRegistrationFlow(t *testing.T) {
-    ctrl := gomock.NewController(t)
-    defer ctrl.Finish()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
 
-    mockLogger := NewMockLoggerInterface(ctrl)
-    mockService := NewMockServiceInterface(ctrl)
-    mockCookieManager := NewMockAuthCookieManagerInterface(ctrl)
-    mockTracer := NewMockTracingInterface(ctrl)
+	mockLogger := NewMockLoggerInterface(ctrl)
+	mockService := NewMockServiceInterface(ctrl)
+	mockCookieManager := NewMockAuthCookieManagerInterface(ctrl)
+	mockTracer := NewMockTracingInterface(ctrl)
 
-    api := NewAPI(mockService, false, false, false, BASE_URL, mockCookieManager, mockTracer, mockLogger)
+	api := NewAPI(mockService, false, false, false, BASE_URL, mockCookieManager, mockTracer, mockLogger)
 
-    t.Run("Missing id parameter", func(t *testing.T) {
-        req := httptest.NewRequest(http.MethodGet, "/registration", nil)
-        w := httptest.NewRecorder()
+	t.Run("Missing id parameter", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/registration", nil)
+		w := httptest.NewRecorder()
 
-        mockLogger.EXPECT().Errorf("ID parameter not present")
+		mockLogger.EXPECT().Errorf("ID parameter not present")
 
-        api.handleGetRegistrationFlow(w, req)
+		api.handleGetRegistrationFlow(w, req)
 
-        res := w.Result()
-        defer res.Body.Close()
+		res := w.Result()
+		defer res.Body.Close()
 
-        if res.StatusCode != http.StatusBadRequest {
-            t.Fatalf("expected %d, got %d", http.StatusBadRequest, res.StatusCode)
-        }
+		if res.StatusCode != http.StatusBadRequest {
+			t.Fatalf("expected %d, got %d", http.StatusBadRequest, res.StatusCode)
+		}
 
-        var body string
-        if err := json.NewDecoder(res.Body).Decode(&body); err != nil {
-            t.Fatalf("unexpected decode error: %v", err)
-        }
-        if body != "ID parameter not present" {
-            t.Fatalf("expected error message 'ID parameter not present', got %q", body)
-        }
-    })
+		var body string
+		if err := json.NewDecoder(res.Body).Decode(&body); err != nil {
+			t.Fatalf("unexpected decode error: %v", err)
+		}
+		if body != "ID parameter not present" {
+			t.Fatalf("expected error message 'ID parameter not present', got %q", body)
+		}
+	})
 
-    t.Run("GetRegistrationFlow returns error", func(t *testing.T) {
-        id := "flow123"
-        req := httptest.NewRequest(http.MethodGet, "/registration?id="+id, nil)
-        w := httptest.NewRecorder()
+	t.Run("GetRegistrationFlow returns error", func(t *testing.T) {
+		id := "flow123"
+		req := httptest.NewRequest(http.MethodGet, "/registration?id="+id, nil)
+		w := httptest.NewRecorder()
 
-        mockService.EXPECT().GetRegistrationFlow(gomock.Any(), id, req.Cookies()).
-            Return(nil, nil, errors.New("some error"))
-        mockLogger.EXPECT().Errorf(gomock.Any(), gomock.Any())
+		mockService.EXPECT().GetRegistrationFlow(gomock.Any(), id, req.Cookies()).
+			Return(nil, nil, errors.New("some error"))
+		mockLogger.EXPECT().Errorf(gomock.Any(), gomock.Any())
 
-        api.handleGetRegistrationFlow(w, req)
+		api.handleGetRegistrationFlow(w, req)
 
-        res := w.Result()
-        defer res.Body.Close()
+		res := w.Result()
+		defer res.Body.Close()
 
-        if res.StatusCode != http.StatusInternalServerError {
-            t.Fatalf("expected %d, got %d", http.StatusInternalServerError, res.StatusCode)
-        }
+		if res.StatusCode != http.StatusInternalServerError {
+			t.Fatalf("expected %d, got %d", http.StatusInternalServerError, res.StatusCode)
+		}
 
-        data, _ := io.ReadAll(res.Body)
-        if !strings.Contains(string(data), "Failed to get registration flow") {
-            t.Fatalf("expected failure message, got %q", string(data))
-        }
-    })
+		data, _ := io.ReadAll(res.Body)
+		if !strings.Contains(string(data), "Failed to get registration flow") {
+			t.Fatalf("expected failure message, got %q", string(data))
+		}
+	})
 
-    t.Run("Success", func(t *testing.T) {
-        id := "flow456"
-        req := httptest.NewRequest(http.MethodGet, "/registration?id="+id, nil)
-        w := httptest.NewRecorder()
+	t.Run("Success", func(t *testing.T) {
+		id := "flow456"
+		req := httptest.NewRequest(http.MethodGet, "/registration?id="+id, nil)
+		w := httptest.NewRecorder()
 
-        flow := kClient.NewRegistrationFlowWithDefaults()
-        flow.SetId(id)
-        cookies := []*http.Cookie{{Name: "test", Value: "ok"}}
+		flow := kClient.NewRegistrationFlowWithDefaults()
+		flow.SetId(id)
+		cookies := []*http.Cookie{{Name: "test", Value: "ok"}}
 
-        mockService.EXPECT().GetRegistrationFlow(gomock.Any(), id, req.Cookies()).
-            Return(flow, cookies, nil)
+		mockService.EXPECT().GetRegistrationFlow(gomock.Any(), id, req.Cookies()).
+			Return(flow, cookies, nil)
 
-        api.handleGetRegistrationFlow(w, req)
+		api.handleGetRegistrationFlow(w, req)
 
-        res := w.Result()
-        defer res.Body.Close()
+		res := w.Result()
+		defer res.Body.Close()
 
-        if res.StatusCode != http.StatusOK {
-            t.Fatalf("expected %d, got %d", http.StatusOK, res.StatusCode)
-        }
+		if res.StatusCode != http.StatusOK {
+			t.Fatalf("expected %d, got %d", http.StatusOK, res.StatusCode)
+		}
 
-        foundCookie := false
-        for _, c := range res.Cookies() {
-            if c.Name == "test" && c.Value == "ok" {
-                foundCookie = true
-            }
-        }
-        if !foundCookie {
-            t.Fatalf("expected cookie 'test=ok' to be set")
-        }
+		foundCookie := false
+		for _, c := range res.Cookies() {
+			if c.Name == "test" && c.Value == "ok" {
+				foundCookie = true
+			}
+		}
+		if !foundCookie {
+			t.Fatalf("expected cookie 'test=ok' to be set")
+		}
 
-        var body map[string]interface{}
-        if err := json.NewDecoder(res.Body).Decode(&body); err != nil {
-            t.Fatalf("unexpected decode error: %v", err)
-        }
+		var body map[string]interface{}
+		if err := json.NewDecoder(res.Body).Decode(&body); err != nil {
+			t.Fatalf("unexpected decode error: %v", err)
+		}
 
-        if body["id"] != id {
-            t.Fatalf("expected id %s, got %v", id, body["id"])
-        }
-    })
+		if body["id"] != id {
+			t.Fatalf("expected id %s, got %v", id, body["id"])
+		}
+	})
 }
 
 func TestHandleUpdateRegistrationFlow(t *testing.T) {
-    ctrl := gomock.NewController(t)
-    defer ctrl.Finish()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
 
-    mockLogger := NewMockLoggerInterface(ctrl)
-    mockService := NewMockServiceInterface(ctrl)
-    mockCookieManager := NewMockAuthCookieManagerInterface(ctrl)
-    mockTracer := NewMockTracingInterface(ctrl)
+	mockLogger := NewMockLoggerInterface(ctrl)
+	mockService := NewMockServiceInterface(ctrl)
+	mockCookieManager := NewMockAuthCookieManagerInterface(ctrl)
+	mockTracer := NewMockTracingInterface(ctrl)
 
-    api := NewAPI(mockService, false, false, false, BASE_URL, mockCookieManager, mockTracer, mockLogger)
+	api := NewAPI(mockService, false, false, false, BASE_URL, mockCookieManager, mockTracer, mockLogger)
 
-    t.Run("ParseRegistrationFlowMethodBody returns error", func(t *testing.T) {
-        req := httptest.NewRequest(http.MethodPost, "/registration/update?flow=e2c802141dc51a06676974687562", nil)
-        w := httptest.NewRecorder()
+	t.Run("ParseRegistrationFlowMethodBody returns error", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/registration/update?flow=e2c802141dc51a06676974687562", nil)
+		w := httptest.NewRecorder()
 
-        mockService.EXPECT().ParseRegistrationFlowMethodBody(req).
-            Return(nil, errors.New("parse error"))
-        mockLogger.EXPECT().Errorf("Error when parsing request body: %v\n", gomock.Any())
+		mockService.EXPECT().ParseRegistrationFlowMethodBody(req).
+			Return(nil, errors.New("parse error"))
+		mockLogger.EXPECT().Errorf("Error when parsing request body: %v\n", gomock.Any())
 
-        api.handleUpdateRegistrationFlow(w, req)
+		api.handleUpdateRegistrationFlow(w, req)
 
-        res := w.Result()
-        defer res.Body.Close()
+		res := w.Result()
+		defer res.Body.Close()
 
-        if res.StatusCode != http.StatusInternalServerError {
-            t.Fatalf("expected %d, got %d", http.StatusInternalServerError, res.StatusCode)
-        }
+		if res.StatusCode != http.StatusInternalServerError {
+			t.Fatalf("expected %d, got %d", http.StatusInternalServerError, res.StatusCode)
+		}
 
-        data, _ := io.ReadAll(res.Body)
-        if !strings.Contains(string(data), "Failed to parse registration flow") {
-            t.Fatalf("expected parse failure message, got %q", string(data))
-        }
-    })
+		data, _ := io.ReadAll(res.Body)
+		if !strings.Contains(string(data), "Failed to parse registration flow") {
+			t.Fatalf("expected parse failure message, got %q", string(data))
+		}
+	})
 
-    t.Run("UpdateRegistrationFlow returns error", func(t *testing.T) {
-        req := httptest.NewRequest(http.MethodPost, "/registration/update?flow=e2c802141dc51a06676974687562", nil)
-        w := httptest.NewRecorder()
+	t.Run("UpdateRegistrationFlow returns error", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/registration/update?flow=e2c802141dc51a06676974687562", nil)
+		w := httptest.NewRecorder()
 
-        body := &kClient.UpdateRegistrationFlowBody{}
-        mockService.EXPECT().ParseRegistrationFlowMethodBody(req).
-            Return(body, nil)
-        mockService.EXPECT().UpdateRegistrationFlow(gomock.Any(), "e2c802141dc51a06676974687562", *body, req.Cookies()).
-            Return(nil, nil, errors.New("update failed"))
-        mockLogger.EXPECT().Errorf("Error when updating registration flow: %v\n", gomock.Any())
+		body := &kClient.UpdateRegistrationFlowBody{}
+		mockService.EXPECT().ParseRegistrationFlowMethodBody(req).
+			Return(body, nil)
+		mockService.EXPECT().UpdateRegistrationFlow(gomock.Any(), "e2c802141dc51a06676974687562", *body, req.Cookies()).
+			Return(nil, nil, errors.New("update failed"))
+		mockLogger.EXPECT().Errorf("Error when updating registration flow: %v\n", gomock.Any())
 
-        api.handleUpdateRegistrationFlow(w, req)
+		api.handleUpdateRegistrationFlow(w, req)
 
-        res := w.Result()
-        defer res.Body.Close()
+		res := w.Result()
+		defer res.Body.Close()
 
-        if res.StatusCode != http.StatusInternalServerError {
-            t.Fatalf("expected %d, got %d", http.StatusInternalServerError, res.StatusCode)
-        }
+		if res.StatusCode != http.StatusInternalServerError {
+			t.Fatalf("expected %d, got %d", http.StatusInternalServerError, res.StatusCode)
+		}
 
-        data, _ := io.ReadAll(res.Body)
-        if !strings.Contains(string(data), "update failed") {
-            t.Fatalf("expected update failure message, got %q", string(data))
-        }
-    })
+		data, _ := io.ReadAll(res.Body)
+		if !strings.Contains(string(data), "update failed") {
+			t.Fatalf("expected update failure message, got %q", string(data))
+		}
+	})
 
-    t.Run("success", func(t *testing.T) {
-        flowID := "e2c802141dc51a06676974687562"
-        req := httptest.NewRequest(http.MethodPost, "/registration/update?flow="+flowID, nil)
-        w := httptest.NewRecorder()
+	t.Run("success", func(t *testing.T) {
+		flowID := "e2c802141dc51a06676974687562"
+		req := httptest.NewRequest(http.MethodPost, "/registration/update?flow="+flowID, nil)
+		w := httptest.NewRecorder()
 
-        body := &kClient.UpdateRegistrationFlowBody{}
-        mockService.EXPECT().ParseRegistrationFlowMethodBody(req).
-            Return(body, nil)
+		body := &kClient.UpdateRegistrationFlowBody{}
+		mockService.EXPECT().ParseRegistrationFlowMethodBody(req).
+			Return(body, nil)
 
-        mockRegistration := &RegistrationFlowResponse{changeRequired: &BrowserLocationChangeRequired{}}
+		mockRegistration := &RegistrationFlowResponse{changeRequired: &BrowserLocationChangeRequired{}}
 
-        cookies := []*http.Cookie{{Name: "updated", Value: "ok"}}
+		cookies := []*http.Cookie{{Name: "updated", Value: "ok"}}
 
-        mockService.EXPECT().UpdateRegistrationFlow(gomock.Any(), flowID, *body, req.Cookies()).
-            Return(mockRegistration, cookies, nil)
+		mockService.EXPECT().UpdateRegistrationFlow(gomock.Any(), flowID, *body, req.Cookies()).
+			Return(mockRegistration, cookies, nil)
 
-        api.handleUpdateRegistrationFlow(w, req)
+		api.handleUpdateRegistrationFlow(w, req)
 
-        res := w.Result()
-        defer res.Body.Close()
+		res := w.Result()
+		defer res.Body.Close()
 
-        if res.StatusCode != http.StatusUnprocessableEntity {
-            t.Fatalf("expected %d, got %d", http.StatusOK, res.StatusCode)
-        }
+		if res.StatusCode != http.StatusUnprocessableEntity {
+			t.Fatalf("expected %d, got %d", http.StatusOK, res.StatusCode)
+		}
 
-        foundCookie := false
-        for _, c := range res.Cookies() {
-            if c.Name == "updated" && c.Value == "ok" {
-                foundCookie = true
-            }
-        }
-        if !foundCookie {
-            t.Fatalf("expected cookie 'updated=ok' to be set")
-        }
-    })
+		foundCookie := false
+		for _, c := range res.Cookies() {
+			if c.Name == "updated" && c.Value == "ok" {
+				foundCookie = true
+			}
+		}
+		if !foundCookie {
+			t.Fatalf("expected cookie 'updated=ok' to be set")
+		}
+	})
 }
-
-
 
 func TestHandleUpdateIdentifierFirstFlow(t *testing.T) {
 	ctrl := gomock.NewController(t)
@@ -1494,7 +1491,7 @@ func TestHandleUpdateFlowRedirectToVerification(t *testing.T) {
 	flowId := "test"
 	identityId := "test"
 	unverifiedEmail := "unverified@example.com"
-	
+
 	flow := kClient.NewLoginFlowWithDefaults()
 	flow.Id = flowId
 	returnToUrl := "https://some/return/url"
@@ -1536,7 +1533,7 @@ func TestHandleUpdateFlowRedirectToVerification(t *testing.T) {
 	if res.StatusCode != http.StatusOK {
 		t.Fatalf("expected HTTP status code 200 got %v", res.StatusCode)
 	}
-	
+
 	loginFlow := BrowserLocationChangeRequired{}
 	if err := json.Unmarshal(data, &loginFlow); err != nil {
 		t.Errorf("expected error to be nil got %v", err)
@@ -2439,459 +2436,457 @@ func TestHandleUpdateSettingsFlowFailOnParseSettingsFlowMethodBody(t *testing.T)
 }
 
 func TestHandleCreateVerificationFlow(t *testing.T) {
-    tests := []struct {
-        name           string
-        setupMocks     func(
-            service *MockServiceInterface,
-            logger *MockLoggerInterface,
-            req *http.Request,
-        )
-        expectedStatus int
-        expectBody     bool
-    }{
-        {
-            name: "service error",
-            setupMocks: func(
-                service *MockServiceInterface,
-                logger *MockLoggerInterface,
-                req *http.Request,
-            ) {
-                service.
-                    EXPECT().
-                    CreateBrowserVerificationFlow(gomock.Any(), req.Cookies()).
-                    Return(nil, nil, errors.New("service error"))
+	tests := []struct {
+		name       string
+		setupMocks func(
+			service *MockServiceInterface,
+			logger *MockLoggerInterface,
+			req *http.Request,
+		)
+		expectedStatus int
+		expectBody     bool
+	}{
+		{
+			name: "service error",
+			setupMocks: func(
+				service *MockServiceInterface,
+				logger *MockLoggerInterface,
+				req *http.Request,
+			) {
+				service.
+					EXPECT().
+					CreateBrowserVerificationFlow(gomock.Any(), req.Cookies()).
+					Return(nil, nil, errors.New("service error"))
 
-                logger.
-                    EXPECT().
-                    Errorf(gomock.Any(), gomock.Any())
-            },
-            expectedStatus: http.StatusInternalServerError,
-            expectBody:     false,
-        },
-        {
-            name: "success",
-            setupMocks: func(
-                service *MockServiceInterface,
-                _ *MockLoggerInterface,
-                req *http.Request,
-            ) {
-                flow := kClient.VerificationFlow{
-                    Id: "verification-flow-id",
-                    State: "mock-state",
-                }
+				logger.
+					EXPECT().
+					Errorf(gomock.Any(), gomock.Any())
+			},
+			expectedStatus: http.StatusInternalServerError,
+			expectBody:     false,
+		},
+		{
+			name: "success",
+			setupMocks: func(
+				service *MockServiceInterface,
+				_ *MockLoggerInterface,
+				req *http.Request,
+			) {
+				flow := kClient.VerificationFlow{
+					Id:    "verification-flow-id",
+					State: "mock-state",
+				}
 
-                service.
-                    EXPECT().
-                    CreateBrowserVerificationFlow(gomock.Any(), req.Cookies()).
-                    Return(&flow, nil, nil)
-            },
-            expectedStatus: http.StatusOK,
-            expectBody:     true,
-        },
-    }
+				service.
+					EXPECT().
+					CreateBrowserVerificationFlow(gomock.Any(), req.Cookies()).
+					Return(&flow, nil, nil)
+			},
+			expectedStatus: http.StatusOK,
+			expectBody:     true,
+		},
+	}
 
-    for _, tt := range tests {
-        t.Run(tt.name, func(t *testing.T) {
-            ctrl := gomock.NewController(t)
-            defer ctrl.Finish()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
 
-            mockLogger := NewMockLoggerInterface(ctrl)
-            mockService := NewMockServiceInterface(ctrl)
-            mockCookieManager := NewMockAuthCookieManagerInterface(ctrl)
-            mockTracer := NewMockTracingInterface(ctrl)
+			mockLogger := NewMockLoggerInterface(ctrl)
+			mockService := NewMockServiceInterface(ctrl)
+			mockCookieManager := NewMockAuthCookieManagerInterface(ctrl)
+			mockTracer := NewMockTracingInterface(ctrl)
 
-            req := httptest.NewRequest(
-                http.MethodGet,
-                HANDLE_CREATE_VERIFICATION_FLOW_URL,
-                nil,
-            )
+			req := httptest.NewRequest(
+				http.MethodGet,
+				HANDLE_CREATE_VERIFICATION_FLOW_URL,
+				nil,
+			)
 
-            if tt.setupMocks != nil {
-                tt.setupMocks(mockService, mockLogger, req)
-            }
+			if tt.setupMocks != nil {
+				tt.setupMocks(mockService, mockLogger, req)
+			}
 
-            w := httptest.NewRecorder()
-            mux := chi.NewMux()
-            NewAPI(
-                mockService,
+			w := httptest.NewRecorder()
+			mux := chi.NewMux()
+			NewAPI(
+				mockService,
 				false,
-                false,
-                false,
-                BASE_URL,
-                mockCookieManager,
-                mockTracer,
-                mockLogger,
-            ).RegisterEndpoints(mux)
+				false,
+				false,
+				BASE_URL,
+				mockCookieManager,
+				mockTracer,
+				mockLogger,
+			).RegisterEndpoints(mux)
 
-            mux.ServeHTTP(w, req)
+			mux.ServeHTTP(w, req)
 
-            res := w.Result()
+			res := w.Result()
 
-            if res.StatusCode != tt.expectedStatus {
-                t.Fatalf(
-                    "Expected status %d, got %d",
-                    tt.expectedStatus,
-                    res.StatusCode,
-                )
-            }
+			if res.StatusCode != tt.expectedStatus {
+				t.Fatalf(
+					"Expected status %d, got %d",
+					tt.expectedStatus,
+					res.StatusCode,
+				)
+			}
 
-            if tt.expectBody {
-                data, err := io.ReadAll(res.Body)
-                if err != nil {
-                    t.Fatalf("Expected error to be nil, got %v", err)
-                }
+			if tt.expectBody {
+				data, err := io.ReadAll(res.Body)
+				if err != nil {
+					t.Fatalf("Expected error to be nil, got %v", err)
+				}
 
-                var flow kClient.VerificationFlow
-                if err := json.Unmarshal(data, &flow); err != nil {
-                    t.Fatalf("Expected error to be nil, got %v", err)
-                }
+				var flow kClient.VerificationFlow
+				if err := json.Unmarshal(data, &flow); err != nil {
+					t.Fatalf("Expected error to be nil, got %v", err)
+				}
 
-                if flow.Id == "" {
-                    t.Fatalf("Expected flow Id to be set")
-                }
-            }
-        })
-    }
+				if flow.Id == "" {
+					t.Fatalf("Expected flow Id to be set")
+				}
+			}
+		})
+	}
 }
-
 
 func TestHandleGetVerificationFlow(t *testing.T) {
-    tests := []struct {
-        name           string
-        queryFlowID    string
-        setupMocks     func(
-            service *MockServiceInterface,
-            logger *MockLoggerInterface,
-            req *http.Request,
-        )
-        expectedStatus int
-        expectBody     bool
-    }{
-        {
-            name:        "missing flow id",
-            queryFlowID: "",
-            setupMocks: func(
-                _ *MockServiceInterface,
-                logger *MockLoggerInterface,
-                _ *http.Request,
-            ) {
-                logger.
-                    EXPECT().
-                    Debug(gomock.Any())
-            },
-            expectedStatus: http.StatusBadRequest,
-            expectBody:     false,
-        },
-        {
-            name:        "service error",
-            queryFlowID: "flow-id",
-            setupMocks: func(
-                service *MockServiceInterface,
-                logger *MockLoggerInterface,
-                req *http.Request,
-            ) {
-                service.
-                    EXPECT().
-                    GetVerificationFlow(
-                        gomock.Any(),
-                        "flow-id",
-                        req.Cookies(),
-                    ).
-                    Return(nil, nil, errors.New("service error"))
+	tests := []struct {
+		name        string
+		queryFlowID string
+		setupMocks  func(
+			service *MockServiceInterface,
+			logger *MockLoggerInterface,
+			req *http.Request,
+		)
+		expectedStatus int
+		expectBody     bool
+	}{
+		{
+			name:        "missing flow id",
+			queryFlowID: "",
+			setupMocks: func(
+				_ *MockServiceInterface,
+				logger *MockLoggerInterface,
+				_ *http.Request,
+			) {
+				logger.
+					EXPECT().
+					Debug(gomock.Any())
+			},
+			expectedStatus: http.StatusBadRequest,
+			expectBody:     false,
+		},
+		{
+			name:        "service error",
+			queryFlowID: "flow-id",
+			setupMocks: func(
+				service *MockServiceInterface,
+				logger *MockLoggerInterface,
+				req *http.Request,
+			) {
+				service.
+					EXPECT().
+					GetVerificationFlow(
+						gomock.Any(),
+						"flow-id",
+						req.Cookies(),
+					).
+					Return(nil, nil, errors.New("service error"))
 
-                logger.
-                    EXPECT().
-                    Errorf(gomock.Any(), gomock.Any())
-            },
-            expectedStatus: http.StatusInternalServerError,
-            expectBody:     false,
-        },
-        {
-            name:        "success",
-            queryFlowID: "flow-id",
-            setupMocks: func(
-                service *MockServiceInterface,
-                _ *MockLoggerInterface,
-                req *http.Request,
-            ) {
-                flow := kClient.VerificationFlow{
-                    Id: "flow-id",
-                    State: "mock-state",
-                }
+				logger.
+					EXPECT().
+					Errorf(gomock.Any(), gomock.Any())
+			},
+			expectedStatus: http.StatusInternalServerError,
+			expectBody:     false,
+		},
+		{
+			name:        "success",
+			queryFlowID: "flow-id",
+			setupMocks: func(
+				service *MockServiceInterface,
+				_ *MockLoggerInterface,
+				req *http.Request,
+			) {
+				flow := kClient.VerificationFlow{
+					Id:    "flow-id",
+					State: "mock-state",
+				}
 
-                service.
-                    EXPECT().
-                    GetVerificationFlow(
-                        gomock.Any(),
-                        "flow-id",
-                        req.Cookies(),
-                    ).
-                    Return(&flow, nil, nil)
-            },
-            expectedStatus: http.StatusOK,
-            expectBody:     true,
-        },
-    }
+				service.
+					EXPECT().
+					GetVerificationFlow(
+						gomock.Any(),
+						"flow-id",
+						req.Cookies(),
+					).
+					Return(&flow, nil, nil)
+			},
+			expectedStatus: http.StatusOK,
+			expectBody:     true,
+		},
+	}
 
-    for _, tt := range tests {
-        t.Run(tt.name, func(t *testing.T) {
-            ctrl := gomock.NewController(t)
-            defer ctrl.Finish()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
 
-            mockLogger := NewMockLoggerInterface(ctrl)
-            mockService := NewMockServiceInterface(ctrl)
-            mockCookieManager := NewMockAuthCookieManagerInterface(ctrl)
-            mockTracer := NewMockTracingInterface(ctrl)
+			mockLogger := NewMockLoggerInterface(ctrl)
+			mockService := NewMockServiceInterface(ctrl)
+			mockCookieManager := NewMockAuthCookieManagerInterface(ctrl)
+			mockTracer := NewMockTracingInterface(ctrl)
 
-            req := httptest.NewRequest(
-                http.MethodGet,
-                HANDLE_GET_VERIFICATION_FLOW_URL,
-                nil,
-            )
+			req := httptest.NewRequest(
+				http.MethodGet,
+				HANDLE_GET_VERIFICATION_FLOW_URL,
+				nil,
+			)
 
-            if tt.queryFlowID != "" {
-                q := req.URL.Query()
-                q.Set("id", tt.queryFlowID)
-                req.URL.RawQuery = q.Encode()
-            }
+			if tt.queryFlowID != "" {
+				q := req.URL.Query()
+				q.Set("id", tt.queryFlowID)
+				req.URL.RawQuery = q.Encode()
+			}
 
-            if tt.setupMocks != nil {
-                tt.setupMocks(mockService, mockLogger, req)
-            }
+			if tt.setupMocks != nil {
+				tt.setupMocks(mockService, mockLogger, req)
+			}
 
-            w := httptest.NewRecorder()
-            mux := chi.NewMux()
-            NewAPI(
-                mockService,
+			w := httptest.NewRecorder()
+			mux := chi.NewMux()
+			NewAPI(
+				mockService,
 				false,
-                false,
-                false,
-                BASE_URL,
-                mockCookieManager,
-                mockTracer,
-                mockLogger,
-            ).RegisterEndpoints(mux)
+				false,
+				false,
+				BASE_URL,
+				mockCookieManager,
+				mockTracer,
+				mockLogger,
+			).RegisterEndpoints(mux)
 
-            mux.ServeHTTP(w, req)
+			mux.ServeHTTP(w, req)
 
-            res := w.Result()
+			res := w.Result()
 
-            if res.StatusCode != tt.expectedStatus {
-                t.Fatalf(
-                    "Expected status %d, got %d",
-                    tt.expectedStatus,
-                    res.StatusCode,
-                )
-            }
+			if res.StatusCode != tt.expectedStatus {
+				t.Fatalf(
+					"Expected status %d, got %d",
+					tt.expectedStatus,
+					res.StatusCode,
+				)
+			}
 
-            if tt.expectBody {
-                data, err := io.ReadAll(res.Body)
-                if err != nil {
-                    t.Fatalf("Expected error to be nil, got %v", err)
-                }
+			if tt.expectBody {
+				data, err := io.ReadAll(res.Body)
+				if err != nil {
+					t.Fatalf("Expected error to be nil, got %v", err)
+				}
 
-                var flow kClient.VerificationFlow
-                if err := json.Unmarshal(data, &flow); err != nil {
-                    t.Fatalf("Expected error to be nil, got %v", err)
-                }
+				var flow kClient.VerificationFlow
+				if err := json.Unmarshal(data, &flow); err != nil {
+					t.Fatalf("Expected error to be nil, got %v", err)
+				}
 
-                if flow.Id != "flow-id" {
-                    t.Fatalf("Expected flow Id to be 'flow-id', got %q", flow.Id)
-                }
-            }
-        })
-    }
+				if flow.Id != "flow-id" {
+					t.Fatalf("Expected flow Id to be 'flow-id', got %q", flow.Id)
+				}
+			}
+		})
+	}
 }
 
-
 func TestHandleUpdateVerificationFlow(t *testing.T) {
-    code := "123456"
+	code := "123456"
 
-    tests := []struct {
-        name           string
-        queryFlowID    string
-        body           any
-        setupMocks     func(
-            service *MockServiceInterface,
-            logger *MockLoggerInterface,
-            req *http.Request,
-        )
-        expectedStatus int
-        expectBody     bool
-    }{
-        {
-            name:        "missing flow id",
-            queryFlowID: "",
-            body:        nil,
-            setupMocks: func(
-                _ *MockServiceInterface,
-                logger *MockLoggerInterface,
-                _ *http.Request,
-            ) {
-                logger.
-                    EXPECT().
-                    Debug(gomock.Any())
-            },
-            expectedStatus: http.StatusBadRequest,
-            expectBody:     false,
-        },
-        {
-            name:        "invalid json body",
-            queryFlowID: "flow-id",
-            body:        make(chan int),
-            setupMocks: func(
-                _ *MockServiceInterface,
-                logger *MockLoggerInterface,
-                _ *http.Request,
-            ) {
-                logger.
-                    EXPECT().
-                    Errorf(gomock.Any(), gomock.Any())
-            },
-            expectedStatus: http.StatusInternalServerError,
-            expectBody:     false,
-        },
-        {
-            name:        "service returns error",
-            queryFlowID: "flow-id",
-            body: kClient.UpdateVerificationFlowBody{
-                UpdateVerificationFlowWithCodeMethod: &kClient.UpdateVerificationFlowWithCodeMethod{
-                    Method: "code",
-                    Code:   &code,
-                },
-            },
-            setupMocks: func(
-                service *MockServiceInterface,
-                logger *MockLoggerInterface,
-                req *http.Request,
-            ) {
-                service.
-                    EXPECT().
-                    UpdateVerificationFlow(
-                        gomock.Any(),
-                        "flow-id",
-                        gomock.Any(),
-                        req.Cookies(),
-                    ).
-                    Return(nil, nil, errors.New("service error"))
+	tests := []struct {
+		name        string
+		queryFlowID string
+		body        any
+		setupMocks  func(
+			service *MockServiceInterface,
+			logger *MockLoggerInterface,
+			req *http.Request,
+		)
+		expectedStatus int
+		expectBody     bool
+	}{
+		{
+			name:        "missing flow id",
+			queryFlowID: "",
+			body:        nil,
+			setupMocks: func(
+				_ *MockServiceInterface,
+				logger *MockLoggerInterface,
+				_ *http.Request,
+			) {
+				logger.
+					EXPECT().
+					Debug(gomock.Any())
+			},
+			expectedStatus: http.StatusBadRequest,
+			expectBody:     false,
+		},
+		{
+			name:        "invalid json body",
+			queryFlowID: "flow-id",
+			body:        make(chan int),
+			setupMocks: func(
+				_ *MockServiceInterface,
+				logger *MockLoggerInterface,
+				_ *http.Request,
+			) {
+				logger.
+					EXPECT().
+					Errorf(gomock.Any(), gomock.Any())
+			},
+			expectedStatus: http.StatusInternalServerError,
+			expectBody:     false,
+		},
+		{
+			name:        "service returns error",
+			queryFlowID: "flow-id",
+			body: kClient.UpdateVerificationFlowBody{
+				UpdateVerificationFlowWithCodeMethod: &kClient.UpdateVerificationFlowWithCodeMethod{
+					Method: "code",
+					Code:   &code,
+				},
+			},
+			setupMocks: func(
+				service *MockServiceInterface,
+				logger *MockLoggerInterface,
+				req *http.Request,
+			) {
+				service.
+					EXPECT().
+					UpdateVerificationFlow(
+						gomock.Any(),
+						"flow-id",
+						gomock.Any(),
+						req.Cookies(),
+					).
+					Return(nil, nil, errors.New("service error"))
 
-                logger.
-                    EXPECT().
-                    Errorf(gomock.Any(), gomock.Any())
-            },
-            expectedStatus: http.StatusInternalServerError,
-            expectBody:     false,
-        },
-        {
-            name:        "success",
-            queryFlowID: "flow-id",
-            body: kClient.UpdateVerificationFlowBody{
-                UpdateVerificationFlowWithCodeMethod: &kClient.UpdateVerificationFlowWithCodeMethod{
-                    Method: "code",
-                    Code:   &code,
-                },
-            },
-            setupMocks: func(
-                service *MockServiceInterface,
-                _ *MockLoggerInterface,
-                req *http.Request,
-            ) {
-                flow := kClient.VerificationFlow{
-                    Id: "flow-id",
-                    State: "mock-state",
-                }
+				logger.
+					EXPECT().
+					Errorf(gomock.Any(), gomock.Any())
+			},
+			expectedStatus: http.StatusInternalServerError,
+			expectBody:     false,
+		},
+		{
+			name:        "success",
+			queryFlowID: "flow-id",
+			body: kClient.UpdateVerificationFlowBody{
+				UpdateVerificationFlowWithCodeMethod: &kClient.UpdateVerificationFlowWithCodeMethod{
+					Method: "code",
+					Code:   &code,
+				},
+			},
+			setupMocks: func(
+				service *MockServiceInterface,
+				_ *MockLoggerInterface,
+				req *http.Request,
+			) {
+				flow := kClient.VerificationFlow{
+					Id:    "flow-id",
+					State: "mock-state",
+				}
 
-                service.
-                    EXPECT().
-                    UpdateVerificationFlow(
-                        gomock.Any(),
-                        "flow-id",
-                        gomock.Any(),
-                        req.Cookies(),
-                    ).
-                    Return(&flow, nil, nil)
-            },
-            expectedStatus: http.StatusOK,
-            expectBody:     true,
-        },
-    }
+				service.
+					EXPECT().
+					UpdateVerificationFlow(
+						gomock.Any(),
+						"flow-id",
+						gomock.Any(),
+						req.Cookies(),
+					).
+					Return(&flow, nil, nil)
+			},
+			expectedStatus: http.StatusOK,
+			expectBody:     true,
+		},
+	}
 
-    for _, tt := range tests {
-        t.Run(tt.name, func(t *testing.T) {
-            ctrl := gomock.NewController(t)
-            defer ctrl.Finish()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
 
-            mockLogger := NewMockLoggerInterface(ctrl)
-            mockService := NewMockServiceInterface(ctrl)
-            mockCookieManager := NewMockAuthCookieManagerInterface(ctrl)
-            mockTracer := NewMockTracingInterface(ctrl)
+			mockLogger := NewMockLoggerInterface(ctrl)
+			mockService := NewMockServiceInterface(ctrl)
+			mockCookieManager := NewMockAuthCookieManagerInterface(ctrl)
+			mockTracer := NewMockTracingInterface(ctrl)
 
-            var bodyReader io.Reader
-            if tt.body != nil {
-                data, err := json.Marshal(tt.body)
-                if err != nil {
-                    bodyReader = bytes.NewReader([]byte("{"))
-                } else {
-                    bodyReader = bytes.NewReader(data)
-                }
-            }
+			var bodyReader io.Reader
+			if tt.body != nil {
+				data, err := json.Marshal(tt.body)
+				if err != nil {
+					bodyReader = bytes.NewReader([]byte("{"))
+				} else {
+					bodyReader = bytes.NewReader(data)
+				}
+			}
 
-            req := httptest.NewRequest(
-                http.MethodPost,
-                HANDLE_UPDATE_VERIFICATION_FLOW_URL,
-                bodyReader,
-            )
+			req := httptest.NewRequest(
+				http.MethodPost,
+				HANDLE_UPDATE_VERIFICATION_FLOW_URL,
+				bodyReader,
+			)
 
-            if tt.queryFlowID != "" {
-                q := req.URL.Query()
-                q.Set("flow", tt.queryFlowID)
-                req.URL.RawQuery = q.Encode()
-            }
+			if tt.queryFlowID != "" {
+				q := req.URL.Query()
+				q.Set("flow", tt.queryFlowID)
+				req.URL.RawQuery = q.Encode()
+			}
 
-            if tt.setupMocks != nil {
-                tt.setupMocks(mockService, mockLogger, req)
-            }
+			if tt.setupMocks != nil {
+				tt.setupMocks(mockService, mockLogger, req)
+			}
 
-            w := httptest.NewRecorder()
-            mux := chi.NewMux()
-            NewAPI(
-                mockService,
+			w := httptest.NewRecorder()
+			mux := chi.NewMux()
+			NewAPI(
+				mockService,
 				false,
-                false,
-                false,
-                BASE_URL,
-                mockCookieManager,
-                mockTracer,
-                mockLogger,
-            ).RegisterEndpoints(mux)
+				false,
+				false,
+				BASE_URL,
+				mockCookieManager,
+				mockTracer,
+				mockLogger,
+			).RegisterEndpoints(mux)
 
-            mux.ServeHTTP(w, req)
+			mux.ServeHTTP(w, req)
 
-            res := w.Result()
+			res := w.Result()
 
-            if res.StatusCode != tt.expectedStatus {
-                t.Fatalf(
-                    "Expected status %d, got %d",
-                    tt.expectedStatus,
-                    res.StatusCode,
-                )
-            }
+			if res.StatusCode != tt.expectedStatus {
+				t.Fatalf(
+					"Expected status %d, got %d",
+					tt.expectedStatus,
+					res.StatusCode,
+				)
+			}
 
-            if tt.expectBody {
-                data, err := io.ReadAll(res.Body)
-                if err != nil {
-                    t.Fatalf("Expected error to be nil, got %v", err)
-                }
+			if tt.expectBody {
+				data, err := io.ReadAll(res.Body)
+				if err != nil {
+					t.Fatalf("Expected error to be nil, got %v", err)
+				}
 
-                var flow = kClient.NewVerificationFlowWithDefaults()
-                if err := json.Unmarshal(data, &flow); err != nil {
-                    t.Fatalf("Expected error to be nil, got %v", err)
-                }
+				var flow = kClient.NewVerificationFlowWithDefaults()
+				if err := json.Unmarshal(data, &flow); err != nil {
+					t.Fatalf("Expected error to be nil, got %v", err)
+				}
 
-                if flow.Id != "flow-id" {
-                    t.Fatalf("Expected flow Id to be 'flow-id', got %q", flow.Id)
-                }
-            }
-        })
-    }
+				if flow.Id != "flow-id" {
+					t.Fatalf("Expected flow Id to be 'flow-id', got %q", flow.Id)
+				}
+			}
+		})
+	}
 }

--- a/pkg/kratos/handlers_test.go
+++ b/pkg/kratos/handlers_test.go
@@ -1789,7 +1789,7 @@ func TestHandleUpdateFlow(t *testing.T) {
 	mockCookieManager.EXPECT().GetStateCookie(gomock.Any()).Return(cookies.FlowStateCookie{}, nil)
 	mockService.EXPECT().CheckSession(gomock.Any(), req.Cookies()).Return(nil, nil, nil)
 	mockCookieManager.EXPECT().SetStateCookie(gomock.Any(), gomock.Any()).Return(nil)
-	mockService.EXPECT().ParseLoginFlowMethodBody(gomock.Any()).Return(flowBody, req.Cookies(), nil)
+	mockService.EXPECT().ParseLoginFlowMethodBody(gomock.Any(), gomock.Any()).Return(flowBody, req.Cookies(), nil)
 	mockService.EXPECT().UpdateLoginFlow(gomock.Any(), flowId, *flowBody, req.Cookies()).Return(redirectFlow, nil, req.Cookies(), nil)
 	mockService.EXPECT().GetLoginFlow(gomock.Any(), flowId, req.Cookies()).Return(flow, nil, nil)
 	mockService.EXPECT().CheckAllowedProvider(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil)
@@ -1840,7 +1840,7 @@ func TestHandleUpdateFlowWhenProviderNotAllowed(t *testing.T) {
 	values.Add("flow", flowId)
 	req.URL.RawQuery = values.Encode()
 
-	mockService.EXPECT().ParseLoginFlowMethodBody(gomock.Any()).Return(flowBody, req.Cookies(), nil)
+	mockService.EXPECT().ParseLoginFlowMethodBody(gomock.Any(), gomock.Any()).Return(flowBody, req.Cookies(), nil)
 	mockService.EXPECT().GetLoginFlow(gomock.Any(), flowId, req.Cookies()).Return(flow, nil, nil)
 	mockService.EXPECT().CheckAllowedProvider(gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
 
@@ -1871,12 +1871,16 @@ func TestHandleUpdateFlowFailOnParseLoginFlowMethodBody(t *testing.T) {
 	flowBody := new(kClient.UpdateLoginFlowBody)
 	flowBody.UpdateLoginFlowWithOidcMethod = kClient.NewUpdateLoginFlowWithOidcMethod("oidc", "oidc")
 
+	loginFlow := kClient.NewLoginFlowWithDefaults()
+	loginFlow.SetRequestedAal("aal1")
+
 	req := httptest.NewRequest(http.MethodPost, HANDLE_UPDATE_LOGIN_FLOW_URL, nil)
 	values := req.URL.Query()
 	values.Add("flow", flowId)
 	req.URL.RawQuery = values.Encode()
 
-	mockService.EXPECT().ParseLoginFlowMethodBody(gomock.Any()).Return(flowBody, nil, fmt.Errorf("error"))
+	mockService.EXPECT().GetLoginFlow(gomock.Any(), flowId, gomock.Any()).Return(loginFlow, nil, nil)
+	mockService.EXPECT().ParseLoginFlowMethodBody(gomock.Any(), gomock.Any()).Return(flowBody, nil, fmt.Errorf("error"))
 	mockLogger.EXPECT().Errorf(gomock.Any(), gomock.Any()).AnyTimes()
 
 	w := httptest.NewRecorder()
@@ -1931,7 +1935,7 @@ func TestHandleUpdateLoginFlowRedirectToRegenerateBackupCodes(t *testing.T) {
 	values.Add("flow", flowId)
 	req.URL.RawQuery = values.Encode()
 
-	mockService.EXPECT().ParseLoginFlowMethodBody(gomock.Any()).Return(flowBody, req.Cookies(), nil)
+	mockService.EXPECT().ParseLoginFlowMethodBody(gomock.Any(), gomock.Any()).Return(flowBody, req.Cookies(), nil)
 	mockService.EXPECT().GetLoginFlow(gomock.Any(), flowId, req.Cookies()).Return(flow, nil, nil)
 	mockService.EXPECT().CheckAllowedProvider(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil)
 	mockService.EXPECT().UpdateLoginFlow(gomock.Any(), flowId, *flowBody, req.Cookies()).Return(redirectFlow, nil, req.Cookies(), nil)
@@ -1986,12 +1990,12 @@ func TestHandleUpdateFlowFailOnUpdateOIDCLoginFlow(t *testing.T) {
 	values.Add("flow", flowId)
 	req.URL.RawQuery = values.Encode()
 
-	mockService.EXPECT().ParseLoginFlowMethodBody(gomock.Any()).Return(flowBody, req.Cookies(), nil)
-	mockCookieManager.EXPECT().GetStateCookie(gomock.Any()).Return(cookies.FlowStateCookie{}, nil)
+	mockService.EXPECT().ParseLoginFlowMethodBody(gomock.Any(), gomock.Any()).Return(flowBody, req.Cookies(), nil)
 	mockService.EXPECT().UpdateLoginFlow(gomock.Any(), flowId, *flowBody, req.Cookies()).Return(nil, nil, nil, fmt.Errorf("error"))
 	mockService.EXPECT().GetLoginFlow(gomock.Any(), flowId, req.Cookies()).Return(flow, nil, nil)
 	mockService.EXPECT().CheckAllowedProvider(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil)
 	mockLogger.EXPECT().Errorf(gomock.Any(), gomock.Any()).AnyTimes()
+	mockCookieManager.EXPECT().GetStateCookie(gomock.Any()).Return(cookies.FlowStateCookie{}, nil)
 
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
@@ -2027,7 +2031,7 @@ func TestHandleUpdateFlowFailOnCheckAllowedProvider(t *testing.T) {
 	values.Add("flow", flowId)
 	req.URL.RawQuery = values.Encode()
 
-	mockService.EXPECT().ParseLoginFlowMethodBody(gomock.Any()).Return(flowBody, req.Cookies(), nil)
+	mockService.EXPECT().ParseLoginFlowMethodBody(gomock.Any(), gomock.Any()).Return(flowBody, req.Cookies(), nil)
 	mockService.EXPECT().GetLoginFlow(gomock.Any(), flowId, req.Cookies()).Return(flow, nil, nil)
 	mockService.EXPECT().CheckAllowedProvider(gomock.Any(), gomock.Any(), gomock.Any()).Return(false, fmt.Errorf("error"))
 	mockLogger.EXPECT().Errorf(gomock.Any(), gomock.Any()).AnyTimes()
@@ -2073,7 +2077,7 @@ func TestHandleUpdateFlowRedirectToVerification(t *testing.T) {
 	values.Add("flow", flowId)
 	req.URL.RawQuery = values.Encode()
 
-	mockService.EXPECT().ParseLoginFlowMethodBody(gomock.Any()).Return(flowBody, req.Cookies(), nil)
+	mockService.EXPECT().ParseLoginFlowMethodBody(gomock.Any(), gomock.Any()).Return(flowBody, req.Cookies(), nil)
 	mockService.EXPECT().GetLoginFlow(gomock.Any(), flowId, req.Cookies()).Return(flow, nil, nil)
 	mockService.EXPECT().CheckAllowedProvider(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil)
 	mockService.EXPECT().UpdateLoginFlow(gomock.Any(), flowId, *flowBody, req.Cookies()).Return(nil, nil, req.Cookies(), nil)
@@ -2138,7 +2142,7 @@ func TestHandleUpdateFlowRequireVerificationError(t *testing.T) {
 	values.Add("flow", flowId)
 	req.URL.RawQuery = values.Encode()
 
-	mockService.EXPECT().ParseLoginFlowMethodBody(gomock.Any()).Return(flowBody, req.Cookies(), nil)
+	mockService.EXPECT().ParseLoginFlowMethodBody(gomock.Any(), gomock.Any()).Return(flowBody, req.Cookies(), nil)
 	mockService.EXPECT().GetLoginFlow(gomock.Any(), flowId, req.Cookies()).Return(flow, nil, nil)
 	mockService.EXPECT().CheckAllowedProvider(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil)
 	mockService.EXPECT().UpdateLoginFlow(gomock.Any(), flowId, *flowBody, req.Cookies()).Return(nil, nil, req.Cookies(), nil)
@@ -3135,12 +3139,6 @@ func TestHandleGetVerificationFlow(t *testing.T) {
 		{
 			name:        "missing flow id",
 			queryFlowID: "",
-			setupMocks: func(
-				_ *MockServiceInterface,
-				logger *MockLoggerInterface,
-				_ *http.Request,
-			) {
-			},
 			expectedStatus: http.StatusBadRequest,
 			expectBody:     false,
 		},
@@ -3282,15 +3280,9 @@ func TestHandleUpdateVerificationFlow(t *testing.T) {
 		expectBody     bool
 	}{
 		{
-			name:        "missing flow id",
-			queryFlowID: "",
-			body:        nil,
-			setupMocks: func(
-				_ *MockServiceInterface,
-				logger *MockLoggerInterface,
-				_ *http.Request,
-			) {
-			},
+			name:           "missing flow id",
+			queryFlowID:    "",
+			body:           nil,
 			expectedStatus: http.StatusBadRequest,
 			expectBody:     false,
 		},

--- a/pkg/kratos/interfaces.go
+++ b/pkg/kratos/interfaces.go
@@ -49,7 +49,7 @@ type ServiceInterface interface {
     GetFlowError(context.Context, string) (*kClient.FlowError, []*http.Cookie, error)
 	CheckAllowedProvider(context.Context, *kClient.LoginFlow, *kClient.UpdateLoginFlowBody) (bool, error)
 	FilterFlowProviderList(context.Context, *kClient.LoginFlow) (*kClient.LoginFlow, error)
-	ParseLoginFlowMethodBody(*http.Request) (*kClient.UpdateLoginFlowBody, []*http.Cookie, error)
+	ParseLoginFlowMethodBody(*http.Request, string) (*kClient.UpdateLoginFlowBody, []*http.Cookie, error)
 	ParseIdentifierFirstLoginFlowMethodBody(*http.Request) (*kClient.UpdateLoginFlowWithIdentifierFirstMethod, []*http.Cookie, error)
 	ParseRegistrationFlowMethodBody(*http.Request) (*kClient.UpdateRegistrationFlowBody, error)
 	ParseRecoveryFlowMethodBody(*http.Request) (*kClient.UpdateRecoveryFlowBody, error)

--- a/pkg/kratos/interfaces.go
+++ b/pkg/kratos/interfaces.go
@@ -88,7 +88,7 @@ type ServiceInterface interface {
 	GetFlowError(context.Context, string) (*kClient.FlowError, []*http.Cookie, error)
 	CheckAllowedProvider(context.Context, *kClient.LoginFlow, *kClient.UpdateLoginFlowBody) (bool, error)
 	FilterFlowProviderList(context.Context, *kClient.LoginFlow) (*kClient.LoginFlow, error)
-	ParseLoginFlowMethodBody(*http.Request) (*kClient.UpdateLoginFlowBody, []*http.Cookie, error)
+	ParseLoginFlowMethodBody(*http.Request, string) (*kClient.UpdateLoginFlowBody, []*http.Cookie, error)
 	ParseIdentifierFirstLoginFlowMethodBody(*http.Request) (*kClient.UpdateLoginFlowWithIdentifierFirstMethod, []*http.Cookie, error)
 	ParseRegistrationFlowMethodBody(*http.Request) (*kClient.UpdateRegistrationFlowBody, error)
 	ParseRecoveryFlowMethodBody(*http.Request) (*kClient.UpdateRecoveryFlowBody, error)

--- a/pkg/kratos/service.go
+++ b/pkg/kratos/service.go
@@ -416,13 +416,13 @@ func passwordPolicyError(flow kClient.RegistrationFlow) error {
 	for _, node := range ui.GetNodes() {
 		if node.GetGroup() == "password" && node.GetType() == "input" && node.GetAttributes().UiNodeInputAttributes.Name == "password" {
 			for _, msg := range node.GetMessages() {
-                // grab and build all errors related to password policy
+				// grab and build all errors related to password policy
 				err = fmt.Errorf("%w ", errors.New(msg.GetText()))
 			}
 
-            if err != nil {
-                return fmt.Errorf("Password policy error: %w", err)
-            }
+			if err != nil {
+				return fmt.Errorf("password policy error: %w", err)
+			}
 		}
 	}
 
@@ -538,66 +538,66 @@ func (s *Service) CreateBrowserSettingsFlow(ctx context.Context, returnTo string
 }
 
 func (s *Service) CreateBrowserVerificationFlow(ctx context.Context, cookies []*http.Cookie) (*kClient.VerificationFlow, []*http.Cookie, error) {
-    ctx, span := s.tracer.Start(ctx, "kratos.Service.CreateBrowserVerificationFlow")
-    defer span.End()
+	ctx, span := s.tracer.Start(ctx, "kratos.Service.CreateBrowserVerificationFlow")
+	defer span.End()
 
-    flow, resp, err := s.kratos.FrontendApi().
-        CreateBrowserVerificationFlow(ctx).
-        Execute()
+	flow, resp, err := s.kratos.FrontendApi().
+		CreateBrowserVerificationFlow(ctx).
+		Execute()
 
-    if err != nil {
-        s.logger.Errorf("unable to create verification flow: %s", err)
-        return nil, nil, fmt.Errorf("unable to create verification flow: %w", err)
-    }
+	if err != nil {
+		s.logger.Errorf("unable to create verification flow: %s", err)
+		return nil, nil, fmt.Errorf("unable to create verification flow: %w", err)
+	}
 
-    if resp != nil {
-        cookies = resp.Cookies()
-    }
+	if resp != nil {
+		cookies = resp.Cookies()
+	}
 
-    return flow, cookies, nil
+	return flow, cookies, nil
 }
 
 func (s *Service) GetVerificationFlow(ctx context.Context, flowId string, cookies []*http.Cookie) (*kClient.VerificationFlow, []*http.Cookie, error) {
-    ctx, span := s.tracer.Start(ctx, "kratos.Service.GetVerificationFlow")
-    defer span.End()
+	ctx, span := s.tracer.Start(ctx, "kratos.Service.GetVerificationFlow")
+	defer span.End()
 
-    req := s.kratos.FrontendApi().GetVerificationFlow(ctx).
-        Id(flowId).
-        Cookie(httpHelpers.CookiesToString(cookies))
+	req := s.kratos.FrontendApi().GetVerificationFlow(ctx).
+		Id(flowId).
+		Cookie(httpHelpers.CookiesToString(cookies))
 
-    flow, response, err := s.kratos.FrontendApi().GetVerificationFlowExecute(req)
-    if err != nil {
-        return nil, nil, fmt.Errorf("unable to fetch verification flow: %w", err)
-    }
+	flow, response, err := s.kratos.FrontendApi().GetVerificationFlowExecute(req)
+	if err != nil {
+		return nil, nil, fmt.Errorf("unable to fetch verification flow: %w", err)
+	}
 
-    if response != nil {
-        cookies = response.Cookies()
-    }
+	if response != nil {
+		cookies = response.Cookies()
+	}
 
-    return flow, cookies, nil
+	return flow, cookies, nil
 }
 
 func (s *Service) UpdateVerificationFlow(ctx context.Context, flowId string, body kClient.UpdateVerificationFlowBody, cookies []*http.Cookie) (*kClient.VerificationFlow, []*http.Cookie, error) {
-    ctx, span := s.tracer.Start(ctx, "kratos.Service.UpdateVerificationFlow")
-    defer span.End()
+	ctx, span := s.tracer.Start(ctx, "kratos.Service.UpdateVerificationFlow")
+	defer span.End()
 
-    req := s.kratos.FrontendApi().UpdateVerificationFlow(ctx).
-        Flow(flowId).
-        Cookie(httpHelpers.CookiesToString(cookies)).
-        UpdateVerificationFlowBody(body)
+	req := s.kratos.FrontendApi().UpdateVerificationFlow(ctx).
+		Flow(flowId).
+		Cookie(httpHelpers.CookiesToString(cookies)).
+		UpdateVerificationFlowBody(body)
 
-    flow, resp, err := s.kratos.FrontendApi().UpdateVerificationFlowExecute(req)
+	flow, resp, err := s.kratos.FrontendApi().UpdateVerificationFlowExecute(req)
 
-    if err != nil {
-        s.logger.Errorf("unable to update verification flow: %s", err)
-        return nil, nil, fmt.Errorf("unable to update verification flow: %w", err)
-    }
+	if err != nil {
+		s.logger.Errorf("unable to update verification flow: %s", err)
+		return nil, nil, fmt.Errorf("unable to update verification flow: %w", err)
+	}
 
-    if resp != nil {
-        cookies = resp.Cookies()
-    }
+	if resp != nil {
+		cookies = resp.Cookies()
+	}
 
-    return flow, cookies, err
+	return flow, cookies, err
 }
 
 func (s *Service) GetLoginFlow(ctx context.Context, id string, cookies []*http.Cookie) (*kClient.LoginFlow, []*http.Cookie, error) {
@@ -1195,7 +1195,7 @@ func (s *Service) ParseIdentifierFirstLoginFlowMethodBody(r *http.Request) (*kCl
 	return &body, cookies, nil
 }
 
-func (s *Service) ParseLoginFlowMethodBody(r *http.Request) (*kClient.UpdateLoginFlowBody, []*http.Cookie, error) {
+func (s *Service) ParseLoginFlowMethodBody(r *http.Request, requestedAAL string) (*kClient.UpdateLoginFlowBody, []*http.Cookie, error) {
 	defer r.Body.Close()
 
 	cookies := r.Cookies()
@@ -1268,8 +1268,10 @@ func (s *Service) ParseLoginFlowMethodBody(r *http.Request) (*kClient.UpdateLogi
 		ret = kClient.UpdateLoginFlowWithOidcMethodAsUpdateLoginFlowBody(&body)
 	}
 
-	// Remove session cookie if this is a 1FA method
-	if s.is1FAMethod(methodPayload.Method) {
+	// Remove session cookie if this is a 1FA method.
+	// When webauthn is used as a 2FA method (requestedAAL == "aal2"), the session
+	// cookie MUST be preserved so Kratos can upgrade the AAL level.
+	if s.is1FAMethod(methodPayload.Method, requestedAAL) {
 		cookies = httpHelpers.FilterCookies(cookies, KRATOS_SESSION_COOKIE_NAME)
 	}
 
@@ -1593,12 +1595,14 @@ func (s *Service) RequireVerificationForEmail(ctx context.Context, session *kCli
 	return false, "", nil
 }
 
-func (s *Service) is1FAMethod(method string) bool {
+func (s *Service) is1FAMethod(method, aal string) bool {
 	switch method {
 	case "password", "oidc":
 		return true
 	case "webauthn":
-		return !s.oidcWebAuthnSequencingEnabled
+		// webauthn is a 2FA method when the flow requests aal2; in that case the
+		// session cookie must NOT be stripped so Kratos can upgrade the AAL level.
+		return aal != "aal2"
 	default:
 		return false
 	}

--- a/pkg/kratos/service.go
+++ b/pkg/kratos/service.go
@@ -1211,7 +1211,7 @@ func (s *Service) ParseIdentifierFirstLoginFlowMethodBody(r *http.Request) (*kCl
 	return &body, cookies, nil
 }
 
-func (s *Service) ParseLoginFlowMethodBody(r *http.Request) (*kClient.UpdateLoginFlowBody, []*http.Cookie, error) {
+func (s *Service) ParseLoginFlowMethodBody(r *http.Request, requestedAAL string) (*kClient.UpdateLoginFlowBody, []*http.Cookie, error) {
 	defer r.Body.Close()
 
 	cookies := r.Cookies()
@@ -1284,8 +1284,10 @@ func (s *Service) ParseLoginFlowMethodBody(r *http.Request) (*kClient.UpdateLogi
 		ret = kClient.UpdateLoginFlowWithOidcMethodAsUpdateLoginFlowBody(&body)
 	}
 
-	// Remove session cookie if this is a 1FA method
-	if s.is1FAMethod(methodPayload.Method) {
+	// Remove session cookie if this is a 1FA method.
+	// When webauthn is used as a 2FA method (requestedAAL == "aal2"), the session
+	// cookie MUST be preserved so Kratos can upgrade the AAL level.
+	if s.is1FAMethod(methodPayload.Method, requestedAAL) {
 		cookies = httpHelpers.FilterCookies(cookies, KRATOS_SESSION_COOKIE_NAME)
 	}
 
@@ -1609,12 +1611,14 @@ func (s *Service) RequireVerificationForEmail(ctx context.Context, session *kCli
 	return false, "", nil
 }
 
-func (s *Service) is1FAMethod(method string) bool {
+func (s *Service) is1FAMethod(method, aal string) bool {
 	switch method {
 	case "password", "oidc":
 		return true
 	case "webauthn":
-		return !s.oidcWebAuthnSequencingEnabled
+		// webauthn is a 2FA method when the flow requests aal2; in that case the
+		// session cookie must NOT be stripped so Kratos can upgrade the AAL level.
+		return aal != "aal2"
 	default:
 		return false
 	}

--- a/pkg/kratos/service_test.go
+++ b/pkg/kratos/service_test.go
@@ -2385,7 +2385,7 @@ func TestParseLoginFlowOidcMethodBody(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodPost, "http://some/path", io.NopCloser(bytes.NewBuffer(jsonBody)))
 
-	b, _, err := NewService(mockKratos, mockAdminKratos, mockHydra, mockAuthz, false, mockTracer, mockMonitor, mockLogger).ParseLoginFlowMethodBody(req)
+	b, _, err := NewService(mockKratos, mockAdminKratos, mockHydra, mockAuthz, false, mockTracer, mockMonitor, mockLogger).ParseLoginFlowMethodBody(req, "aal1")
 
 	actual, _ := b.MarshalJSON()
 	expected, _ := body.MarshalJSON()
@@ -2418,7 +2418,7 @@ func TestParseLoginFlowPasswordMethodBody(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodPost, "http://some/path", io.NopCloser(bytes.NewBuffer(jsonBody)))
 
-	b, _, err := NewService(mockKratos, mockAdminKratos, mockHydra, mockAuthz, false, mockTracer, mockMonitor, mockLogger).ParseLoginFlowMethodBody(req)
+	b, _, err := NewService(mockKratos, mockAdminKratos, mockHydra, mockAuthz, false, mockTracer, mockMonitor, mockLogger).ParseLoginFlowMethodBody(req, "aal1")
 
 	actual, _ := b.MarshalJSON()
 	expected, _ := body.MarshalJSON()
@@ -2452,7 +2452,7 @@ func TestParseLoginFlowTotpMethodBody(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodPost, "http://some/path", io.NopCloser(bytes.NewBuffer(jsonBody)))
 
-	b, _, err := NewService(mockKratos, mockAdminKratos, mockHydra, mockAuthz, false, mockTracer, mockMonitor, mockLogger).ParseLoginFlowMethodBody(req)
+	b, _, err := NewService(mockKratos, mockAdminKratos, mockHydra, mockAuthz, false, mockTracer, mockMonitor, mockLogger).ParseLoginFlowMethodBody(req, "aal1")
 
 	actual, _ := b.MarshalJSON()
 	expected, _ := body.MarshalJSON()
@@ -2486,7 +2486,7 @@ func TestParseLoginFlowLookupSecretMethodBody(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodPost, "http://some/path", io.NopCloser(bytes.NewBuffer(jsonBody)))
 
-	b, _, err := NewService(mockKratos, mockAdminKratos, mockHydra, mockAuthz, false, mockTracer, mockMonitor, mockLogger).ParseLoginFlowMethodBody(req)
+	b, _, err := NewService(mockKratos, mockAdminKratos, mockHydra, mockAuthz, false, mockTracer, mockMonitor, mockLogger).ParseLoginFlowMethodBody(req, "aal1")
 
 	actual, _ := b.MarshalJSON()
 	expected, _ := body.MarshalJSON()
@@ -2520,7 +2520,7 @@ func TestParseLoginFlowWebAuthnMethodBody(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodPost, "http://some/path", io.NopCloser(bytes.NewBuffer(jsonBody)))
 
-	b, _, err := NewService(mockKratos, mockAdminKratos, mockHydra, mockAuthz, false, mockTracer, mockMonitor, mockLogger).ParseLoginFlowMethodBody(req)
+	b, _, err := NewService(mockKratos, mockAdminKratos, mockHydra, mockAuthz, false, mockTracer, mockMonitor, mockLogger).ParseLoginFlowMethodBody(req, "aal1")
 
 	actual, _ := b.MarshalJSON()
 	expected, _ := body.MarshalJSON()
@@ -2530,6 +2530,53 @@ func TestParseLoginFlowWebAuthnMethodBody(t *testing.T) {
 	}
 	if err != nil {
 		t.Fatalf("expected error to be nil not  %v", err)
+	}
+}
+
+// TestParseLoginFlowWebAuthnMethodBodyPreservesSessionCookieForAAL2 is a regression
+// test for issue #839: when webauthn is used as a 2FA method (alongside TOTP), the
+// Kratos session cookie must NOT be stripped, because Kratos needs it to associate
+// the webauthn authentication with the existing AAL1 session.
+// With oidcWebAuthnSequencingEnabled=false the old code treated webauthn as 1FA and
+// therefore incorrectly filtered the session cookie.
+func TestParseLoginFlowWebAuthnMethodBodyPreservesSessionCookieForAAL2(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := NewMockLoggerInterface(ctrl)
+	mockHydra := NewMockHydraClientInterface(ctrl)
+	mockKratos := NewMockKratosClientInterface(ctrl)
+	mockAdminKratos := NewMockKratosAdminClientInterface(ctrl)
+	mockAuthz := NewMockAuthorizerInterface(ctrl)
+	mockTracer := NewMockTracingInterface(ctrl)
+	mockMonitor := monitoring.NewMockMonitorInterface(ctrl)
+
+	flow := kClient.NewUpdateLoginFlowWithWebAuthnMethodWithDefaults()
+	flow.SetMethod("webauthn")
+
+	body := kClient.UpdateLoginFlowWithWebAuthnMethodAsUpdateLoginFlowBody(flow)
+	jsonBody, _ := body.MarshalJSON()
+
+	req := httptest.NewRequest(http.MethodPost, "http://some/path", io.NopCloser(bytes.NewBuffer(jsonBody)))
+	req.AddCookie(&http.Cookie{Name: KRATOS_SESSION_COOKIE_NAME, Value: "session_token"})
+
+	// oidcWebAuthnSequencingEnabled=false (standard MFA mode), requestedAAL="aal2" (2FA step)
+	_, cookies, err := NewService(mockKratos, mockAdminKratos, mockHydra, mockAuthz, false, mockTracer, mockMonitor, mockLogger).ParseLoginFlowMethodBody(req, "aal2")
+
+	if err != nil {
+		t.Fatalf("expected error to be nil not %v", err)
+	}
+
+	sessionCookiePresent := false
+	for _, c := range cookies {
+		if c.Name == KRATOS_SESSION_COOKIE_NAME {
+			sessionCookiePresent = true
+			break
+		}
+	}
+
+	if !sessionCookiePresent {
+		t.Fatal("bug #839: session cookie was incorrectly stripped for webauthn 2FA when oidcWebAuthnSequencingEnabled=false")
 	}
 }
 
@@ -2565,7 +2612,7 @@ func TestGetProviderNameOidc(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodPost, "http://some/path", io.NopCloser(bytes.NewBuffer(jsonBody)))
 
-	b, _, _ := NewService(mockKratos, mockAdminKratos, mockHydra, mockAuthz, false, mockTracer, mockMonitor, mockLogger).ParseLoginFlowMethodBody(req)
+	b, _, _ := NewService(mockKratos, mockAdminKratos, mockHydra, mockAuthz, false, mockTracer, mockMonitor, mockLogger).ParseLoginFlowMethodBody(req, "aal1")
 
 	actualProviderName := b.UpdateLoginFlowWithOidcMethod.Provider
 	if expectedProviderName != actualProviderName {

--- a/pkg/kratos/service_test.go
+++ b/pkg/kratos/service_test.go
@@ -3840,12 +3840,12 @@ func TestRequireVerificationForEmail(t *testing.T) {
 	oidcMethod := "oidc"
 
 	tests := []struct {
-		name              string
-		setupSession      func() *kClient.Session
-		expectEnforce     bool
-		expectEmail       string
-		expectError       bool
-		expectDebugLog    bool
+		name           string
+		setupSession   func() *kClient.Session
+		expectEnforce  bool
+		expectEmail    string
+		expectError    bool
+		expectDebugLog bool
 	}{
 		{
 			name: "Nil session returns false",
@@ -4110,573 +4110,573 @@ func TestHasWebAuthnAvailableFailOnGetIdentityExecute(t *testing.T) {
 }
 
 func TestCreateVerificationFlowSuccess(t *testing.T) {
-    ctrl := gomock.NewController(t)
-    defer ctrl.Finish()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
 
-    mockLogger := NewMockLoggerInterface(ctrl)
-    mockKratos := NewMockKratosClientInterface(ctrl)
-    mockTracer := NewMockTracingInterface(ctrl)
-    mockMonitor := monitoring.NewMockMonitorInterface(ctrl)
-    mockKratosFrontendApi := NewMockFrontendAPI(ctrl)
+	mockLogger := NewMockLoggerInterface(ctrl)
+	mockKratos := NewMockKratosClientInterface(ctrl)
+	mockTracer := NewMockTracingInterface(ctrl)
+	mockMonitor := monitoring.NewMockMonitorInterface(ctrl)
+	mockKratosFrontendApi := NewMockFrontendAPI(ctrl)
 
-    ctx := context.Background()
+	ctx := context.Background()
 
-    // input cookies
-    cookies := make([]*http.Cookie, 0)
-    cookie := &http.Cookie{Name: "test", Value: "test"}
-    cookies = append(cookies, cookie)
+	// input cookies
+	cookies := make([]*http.Cookie, 0)
+	cookie := &http.Cookie{Name: "test", Value: "test"}
+	cookies = append(cookies, cookie)
 
-    // expected flow
-    flow := kClient.NewVerificationFlowWithDefaults()
+	// expected flow
+	flow := kClient.NewVerificationFlowWithDefaults()
 
-    // kratos request
-    request := kClient.FrontendAPICreateBrowserVerificationFlowRequest{
-        ApiService: mockKratosFrontendApi,
-    }
+	// kratos request
+	request := kClient.FrontendAPICreateBrowserVerificationFlowRequest{
+		ApiService: mockKratosFrontendApi,
+	}
 
-    // http response with cookies
-    resp := http.Response{
-        Header: http.Header{
-            "Set-Cookie": []string{cookie.Raw},
-        },
-    }
+	// http response with cookies
+	resp := http.Response{
+		Header: http.Header{
+			"Set-Cookie": []string{cookie.Raw},
+		},
+	}
 
-    mockTracer.
-        EXPECT().
-        Start(ctx, "kratos.Service.CreateBrowserVerificationFlow").
-        Times(1).
-        Return(ctx, trace.SpanFromContext(ctx))
+	mockTracer.
+		EXPECT().
+		Start(ctx, "kratos.Service.CreateBrowserVerificationFlow").
+		Times(1).
+		Return(ctx, trace.SpanFromContext(ctx))
 
-    mockKratos.
-        EXPECT().
-        FrontendApi().
-        Times(1).
-        Return(mockKratosFrontendApi)
+	mockKratos.
+		EXPECT().
+		FrontendApi().
+		Times(1).
+		Return(mockKratosFrontendApi)
 
-    mockKratosFrontendApi.
-        EXPECT().
-        CreateBrowserVerificationFlow(ctx).
-        Times(1).
-        Return(request)
+	mockKratosFrontendApi.
+		EXPECT().
+		CreateBrowserVerificationFlow(ctx).
+		Times(1).
+		Return(request)
 
-    mockKratosFrontendApi.
-        EXPECT().
-        CreateBrowserVerificationFlowExecute(gomock.Any()).
-        Times(1).
-        DoAndReturn(func(
-            r kClient.FrontendAPICreateBrowserVerificationFlowRequest,
-        ) (*kClient.VerificationFlow, *http.Response, error) {
-            return flow, &resp, nil
-        })
+	mockKratosFrontendApi.
+		EXPECT().
+		CreateBrowserVerificationFlowExecute(gomock.Any()).
+		Times(1).
+		DoAndReturn(func(
+			r kClient.FrontendAPICreateBrowserVerificationFlowRequest,
+		) (*kClient.VerificationFlow, *http.Response, error) {
+			return flow, &resp, nil
+		})
 
-    f, c, err := NewService(
-        mockKratos,
-        nil, // admin kratos
-        nil, // hydra
-        nil, // authz
-        false,
-        mockTracer,
-        mockMonitor,
-        mockLogger,
-    ).CreateBrowserVerificationFlow(ctx, cookies)
+	f, c, err := NewService(
+		mockKratos,
+		nil, // admin kratos
+		nil, // hydra
+		nil, // authz
+		false,
+		mockTracer,
+		mockMonitor,
+		mockLogger,
+	).CreateBrowserVerificationFlow(ctx, cookies)
 
-    if f != flow {
-        t.Fatalf("expected flow to be %v, got %v", flow, f)
-    }
+	if f != flow {
+		t.Fatalf("expected flow to be %v, got %v", flow, f)
+	}
 
-    if !reflect.DeepEqual(c, resp.Cookies()) {
-        t.Fatalf("expected cookies to be %v, got %v", resp.Cookies(), c)
-    }
+	if !reflect.DeepEqual(c, resp.Cookies()) {
+		t.Fatalf("expected cookies to be %v, got %v", resp.Cookies(), c)
+	}
 
-    if err != nil {
-        t.Fatalf("expected error to be nil, got %v", err)
-    }
+	if err != nil {
+		t.Fatalf("expected error to be nil, got %v", err)
+	}
 }
 
 func TestCreateVerificationFlowError(t *testing.T) {
-    ctrl := gomock.NewController(t)
-    defer ctrl.Finish()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
 
-    mockLogger := NewMockLoggerInterface(ctrl)
-    mockKratos := NewMockKratosClientInterface(ctrl)
-    mockTracer := NewMockTracingInterface(ctrl)
-    mockMonitor := monitoring.NewMockMonitorInterface(ctrl)
-    mockKratosFrontendApi := NewMockFrontendAPI(ctrl)
+	mockLogger := NewMockLoggerInterface(ctrl)
+	mockKratos := NewMockKratosClientInterface(ctrl)
+	mockTracer := NewMockTracingInterface(ctrl)
+	mockMonitor := monitoring.NewMockMonitorInterface(ctrl)
+	mockKratosFrontendApi := NewMockFrontendAPI(ctrl)
 
-    ctx := context.Background()
+	ctx := context.Background()
 
-    request := kClient.FrontendAPICreateBrowserVerificationFlowRequest{
-        ApiService: mockKratosFrontendApi,
-    }
+	request := kClient.FrontendAPICreateBrowserVerificationFlowRequest{
+		ApiService: mockKratosFrontendApi,
+	}
 
-    mockTracer.
-        EXPECT().
-        Start(ctx, "kratos.Service.CreateBrowserVerificationFlow").
-        Times(1).
-        Return(ctx, trace.SpanFromContext(ctx))
+	mockTracer.
+		EXPECT().
+		Start(ctx, "kratos.Service.CreateBrowserVerificationFlow").
+		Times(1).
+		Return(ctx, trace.SpanFromContext(ctx))
 
-    mockKratos.
-        EXPECT().
-        FrontendApi().
-        Times(1).
-        Return(mockKratosFrontendApi)
+	mockKratos.
+		EXPECT().
+		FrontendApi().
+		Times(1).
+		Return(mockKratosFrontendApi)
 
-    mockKratosFrontendApi.
-        EXPECT().
-        CreateBrowserVerificationFlow(ctx).
-        Times(1).
-        Return(request)
+	mockKratosFrontendApi.
+		EXPECT().
+		CreateBrowserVerificationFlow(ctx).
+		Times(1).
+		Return(request)
 
-    mockKratosFrontendApi.
-        EXPECT().
-        CreateBrowserVerificationFlowExecute(gomock.Any()).
-        Times(1).
-        Return(nil, nil, fmt.Errorf("kratos error"))
+	mockKratosFrontendApi.
+		EXPECT().
+		CreateBrowserVerificationFlowExecute(gomock.Any()).
+		Times(1).
+		Return(nil, nil, fmt.Errorf("kratos error"))
 
-    mockLogger.
-        EXPECT().
-        Errorf(gomock.Any(), gomock.Any()).
-        Times(1)
+	mockLogger.
+		EXPECT().
+		Errorf(gomock.Any(), gomock.Any()).
+		Times(1)
 
-    f, c, err := NewService(
-        mockKratos,
-        nil,
-        nil,
-        nil,
-        false,
-        mockTracer,
-        mockMonitor,
-        mockLogger,
-    ).CreateBrowserVerificationFlow(ctx, nil)
+	f, c, err := NewService(
+		mockKratos,
+		nil,
+		nil,
+		nil,
+		false,
+		mockTracer,
+		mockMonitor,
+		mockLogger,
+	).CreateBrowserVerificationFlow(ctx, nil)
 
-    if f != nil {
-        t.Fatalf("expected flow to be nil, got %v", f)
-    }
+	if f != nil {
+		t.Fatalf("expected flow to be nil, got %v", f)
+	}
 
-    if c != nil {
-        t.Fatalf("expected cookies to be nil, got %v", c)
-    }
+	if c != nil {
+		t.Fatalf("expected cookies to be nil, got %v", c)
+	}
 
-    if err == nil {
-        t.Fatalf("expected error, got nil")
-    }
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
 }
 
 func TestService_GetVerificationFlow(t *testing.T) {
 
-    t.Run("kratos returns error", func(t *testing.T) {
-        ctrl := gomock.NewController(t)
-        defer ctrl.Finish()
+	t.Run("kratos returns error", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
 
-        ctx := context.Background()
+		ctx := context.Background()
 
-        mockTracer := NewMockTracingInterface(ctrl)
-        mockLogger := NewMockLoggerInterface(ctrl)
-        mockKratos := NewMockKratosClientInterface(ctrl)
-        mockFrontend := NewMockFrontendAPI(ctrl)
-        mockMonitor := monitoring.NewMockMonitorInterface(ctrl)
+		mockTracer := NewMockTracingInterface(ctrl)
+		mockLogger := NewMockLoggerInterface(ctrl)
+		mockKratos := NewMockKratosClientInterface(ctrl)
+		mockFrontend := NewMockFrontendAPI(ctrl)
+		mockMonitor := monitoring.NewMockMonitorInterface(ctrl)
 
-        flowID := "flow-id"
+		flowID := "flow-id"
 
-        mockTracer.
-            EXPECT().
-            Start(ctx, "kratos.Service.GetVerificationFlow").
-            Times(1).
-            Return(ctx, trace.SpanFromContext(ctx))
+		mockTracer.
+			EXPECT().
+			Start(ctx, "kratos.Service.GetVerificationFlow").
+			Times(1).
+			Return(ctx, trace.SpanFromContext(ctx))
 
-        mockKratos.
-            EXPECT().
-            FrontendApi().
-            Times(2).
-            Return(mockFrontend)
+		mockKratos.
+			EXPECT().
+			FrontendApi().
+			Times(2).
+			Return(mockFrontend)
 
-        req := kClient.FrontendAPIGetVerificationFlowRequest{
-            ApiService: mockFrontend,
-        }
+		req := kClient.FrontendAPIGetVerificationFlowRequest{
+			ApiService: mockFrontend,
+		}
 
-        mockFrontend.
-            EXPECT().
-            GetVerificationFlow(ctx).
-            Times(1).
-            Return(req)
+		mockFrontend.
+			EXPECT().
+			GetVerificationFlow(ctx).
+			Times(1).
+			Return(req)
 
-        mockFrontend.
-            EXPECT().
-            GetVerificationFlowExecute(gomock.Any()).
-            Times(1).
-            Return(nil, nil, fmt.Errorf("kratos error"))
+		mockFrontend.
+			EXPECT().
+			GetVerificationFlowExecute(gomock.Any()).
+			Times(1).
+			Return(nil, nil, fmt.Errorf("kratos error"))
 
-        svc := NewService(
-            mockKratos,
-            nil,
-            nil,
-            nil,
-            false,
-            mockTracer,
-            mockMonitor,
-            mockLogger,
-        )
+		svc := NewService(
+			mockKratos,
+			nil,
+			nil,
+			nil,
+			false,
+			mockTracer,
+			mockMonitor,
+			mockLogger,
+		)
 
-        f, c, err := svc.GetVerificationFlow(ctx, flowID, nil)
+		f, c, err := svc.GetVerificationFlow(ctx, flowID, nil)
 
-        if f != nil {
-            t.Fatalf("expected flow to be nil, got %v", f)
-        }
+		if f != nil {
+			t.Fatalf("expected flow to be nil, got %v", f)
+		}
 
-        if c != nil {
-            t.Fatalf("expected cookies to be nil, got %v", c)
-        }
+		if c != nil {
+			t.Fatalf("expected cookies to be nil, got %v", c)
+		}
 
-        if err == nil {
-            t.Fatalf("expected error, got nil")
-        }
-    })
+		if err == nil {
+			t.Fatalf("expected error, got nil")
+		}
+	})
 
-    t.Run("success without response cookies", func(t *testing.T) {
-        ctrl := gomock.NewController(t)
-        defer ctrl.Finish()
+	t.Run("success without response cookies", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
 
-        ctx := context.Background()
+		ctx := context.Background()
 
-        mockTracer := NewMockTracingInterface(ctrl)
-        mockLogger := NewMockLoggerInterface(ctrl)
-        mockKratos := NewMockKratosClientInterface(ctrl)
-        mockFrontend := NewMockFrontendAPI(ctrl)
-        mockMonitor := monitoring.NewMockMonitorInterface(ctrl)
+		mockTracer := NewMockTracingInterface(ctrl)
+		mockLogger := NewMockLoggerInterface(ctrl)
+		mockKratos := NewMockKratosClientInterface(ctrl)
+		mockFrontend := NewMockFrontendAPI(ctrl)
+		mockMonitor := monitoring.NewMockMonitorInterface(ctrl)
 
-        flowID := "flow-id"
+		flowID := "flow-id"
 
-        mockTracer.
-            EXPECT().
-            Start(ctx, "kratos.Service.GetVerificationFlow").
-            Times(1).
-            Return(ctx, trace.SpanFromContext(ctx))
+		mockTracer.
+			EXPECT().
+			Start(ctx, "kratos.Service.GetVerificationFlow").
+			Times(1).
+			Return(ctx, trace.SpanFromContext(ctx))
 
-        mockKratos.
-            EXPECT().
-            FrontendApi().
-            Times(2).
-            Return(mockFrontend)
+		mockKratos.
+			EXPECT().
+			FrontendApi().
+			Times(2).
+			Return(mockFrontend)
 
-        req := kClient.FrontendAPIGetVerificationFlowRequest{
-            ApiService: mockFrontend,
-        }
+		req := kClient.FrontendAPIGetVerificationFlowRequest{
+			ApiService: mockFrontend,
+		}
 
-        mockFrontend.
-            EXPECT().
-            GetVerificationFlow(ctx).
-            Times(1).
-            Return(req)
+		mockFrontend.
+			EXPECT().
+			GetVerificationFlow(ctx).
+			Times(1).
+			Return(req)
 
-        flow := &kClient.VerificationFlow{
-            Id: flowID,
-        }
+		flow := &kClient.VerificationFlow{
+			Id: flowID,
+		}
 
-        mockFrontend.
-            EXPECT().
-            GetVerificationFlowExecute(gomock.Any()).
-            Times(1).
-            Return(flow, nil, nil)
+		mockFrontend.
+			EXPECT().
+			GetVerificationFlowExecute(gomock.Any()).
+			Times(1).
+			Return(flow, nil, nil)
 
-        svc := NewService(
-            mockKratos,
-            nil,
-            nil,
-            nil,
-            false,
-            mockTracer,
-            mockMonitor,
-            mockLogger,
-        )
+		svc := NewService(
+			mockKratos,
+			nil,
+			nil,
+			nil,
+			false,
+			mockTracer,
+			mockMonitor,
+			mockLogger,
+		)
 
-        f, c, err := svc.GetVerificationFlow(ctx, flowID, nil)
+		f, c, err := svc.GetVerificationFlow(ctx, flowID, nil)
 
-        if err != nil {
-            t.Fatalf("expected error to be nil, got %v", err)
-        }
+		if err != nil {
+			t.Fatalf("expected error to be nil, got %v", err)
+		}
 
-        if f != flow {
-            t.Fatalf("expected flow %v, got %v", flow, f)
-        }
+		if f != flow {
+			t.Fatalf("expected flow %v, got %v", flow, f)
+		}
 
-        if c != nil {
-            t.Fatalf("expected cookies to be nil, got %v", c)
-        }
-    })
+		if c != nil {
+			t.Fatalf("expected cookies to be nil, got %v", c)
+		}
+	})
 
-    t.Run("success with response cookies", func(t *testing.T) {
-        ctrl := gomock.NewController(t)
-        defer ctrl.Finish()
+	t.Run("success with response cookies", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
 
-        ctx := context.Background()
+		ctx := context.Background()
 
-        mockTracer := NewMockTracingInterface(ctrl)
-        mockLogger := NewMockLoggerInterface(ctrl)
-        mockKratos := NewMockKratosClientInterface(ctrl)
-        mockFrontend := NewMockFrontendAPI(ctrl)
-        mockMonitor := monitoring.NewMockMonitorInterface(ctrl)
+		mockTracer := NewMockTracingInterface(ctrl)
+		mockLogger := NewMockLoggerInterface(ctrl)
+		mockKratos := NewMockKratosClientInterface(ctrl)
+		mockFrontend := NewMockFrontendAPI(ctrl)
+		mockMonitor := monitoring.NewMockMonitorInterface(ctrl)
 
-        flowID := "flow-id"
+		flowID := "flow-id"
 
-        mockTracer.
-            EXPECT().
-            Start(ctx, "kratos.Service.GetVerificationFlow").
-            Times(1).
-            Return(ctx, trace.SpanFromContext(ctx))
+		mockTracer.
+			EXPECT().
+			Start(ctx, "kratos.Service.GetVerificationFlow").
+			Times(1).
+			Return(ctx, trace.SpanFromContext(ctx))
 
-        mockKratos.
-            EXPECT().
-            FrontendApi().
-            Times(2).
-            Return(mockFrontend)
+		mockKratos.
+			EXPECT().
+			FrontendApi().
+			Times(2).
+			Return(mockFrontend)
 
-        req := kClient.FrontendAPIGetVerificationFlowRequest{
-            ApiService: mockFrontend,
-        }
+		req := kClient.FrontendAPIGetVerificationFlowRequest{
+			ApiService: mockFrontend,
+		}
 
-        mockFrontend.
-            EXPECT().
-            GetVerificationFlow(ctx).
-            Times(1).
-            Return(req)
+		mockFrontend.
+			EXPECT().
+			GetVerificationFlow(ctx).
+			Times(1).
+			Return(req)
 
-        flow := &kClient.VerificationFlow{
-            Id: flowID,
-        }
+		flow := &kClient.VerificationFlow{
+			Id: flowID,
+		}
 
-        cookie := &http.Cookie{
-            Name:  "kratos",
-            Value: "test",
-        }
+		cookie := &http.Cookie{
+			Name:  "kratos",
+			Value: "test",
+		}
 
-        resp := &http.Response{
-            Header: http.Header{
-                "Set-Cookie": []string{cookie.Raw},
-            },
-        }
+		resp := &http.Response{
+			Header: http.Header{
+				"Set-Cookie": []string{cookie.Raw},
+			},
+		}
 
-        mockFrontend.
-            EXPECT().
-            GetVerificationFlowExecute(gomock.Any()).
-            Times(1).
-            Return(flow, resp, nil)
+		mockFrontend.
+			EXPECT().
+			GetVerificationFlowExecute(gomock.Any()).
+			Times(1).
+			Return(flow, resp, nil)
 
-        svc := NewService(
-            mockKratos,
-            nil,
-            nil,
-            nil,
-            false,
-            mockTracer,
-            mockMonitor,
-            mockLogger,
-        )
+		svc := NewService(
+			mockKratos,
+			nil,
+			nil,
+			nil,
+			false,
+			mockTracer,
+			mockMonitor,
+			mockLogger,
+		)
 
-        f, c, err := svc.GetVerificationFlow(ctx, flowID, nil)
+		f, c, err := svc.GetVerificationFlow(ctx, flowID, nil)
 
-        if err != nil {
-            t.Fatalf("expected error to be nil, got %v", err)
-        }
+		if err != nil {
+			t.Fatalf("expected error to be nil, got %v", err)
+		}
 
-        if f != flow {
-            t.Fatalf("expected flow %v, got %v", flow, f)
-        }
+		if f != flow {
+			t.Fatalf("expected flow %v, got %v", flow, f)
+		}
 
-        if !reflect.DeepEqual(c, resp.Cookies()) {
-            t.Fatalf("expected cookies %v, got %v", resp.Cookies(), c)
-        }
-    })
+		if !reflect.DeepEqual(c, resp.Cookies()) {
+			t.Fatalf("expected cookies %v, got %v", resp.Cookies(), c)
+		}
+	})
 }
 
 func TestService_UpdateVerificationFlow(t *testing.T) {
 
-    code := "123456"
-    body := kClient.UpdateVerificationFlowBody{
-        UpdateVerificationFlowWithCodeMethod: &kClient.UpdateVerificationFlowWithCodeMethod{
-            Method: "code",
-            Code:   &code,
-        },
-    }
+	code := "123456"
+	body := kClient.UpdateVerificationFlowBody{
+		UpdateVerificationFlowWithCodeMethod: &kClient.UpdateVerificationFlowWithCodeMethod{
+			Method: "code",
+			Code:   &code,
+		},
+	}
 
-    t.Run("kratos returns error", func(t *testing.T) {
-        ctrl := gomock.NewController(t)
-        defer ctrl.Finish()
+	t.Run("kratos returns error", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
 
-        ctx := context.Background()
-        mockTracer := NewMockTracingInterface(ctrl)
-        mockLogger := NewMockLoggerInterface(ctrl)
-        mockKratos := NewMockKratosClientInterface(ctrl)
-        mockFrontend := NewMockFrontendAPI(ctrl)
-        mockMonitor := monitoring.NewMockMonitorInterface(ctrl)
+		ctx := context.Background()
+		mockTracer := NewMockTracingInterface(ctrl)
+		mockLogger := NewMockLoggerInterface(ctrl)
+		mockKratos := NewMockKratosClientInterface(ctrl)
+		mockFrontend := NewMockFrontendAPI(ctrl)
+		mockMonitor := monitoring.NewMockMonitorInterface(ctrl)
 
-        flowID := "flow-id"
+		flowID := "flow-id"
 
-        mockTracer.
-            EXPECT().
-            Start(ctx, "kratos.Service.UpdateVerificationFlow").
-            Times(1).
-            Return(ctx, trace.SpanFromContext(ctx))
+		mockTracer.
+			EXPECT().
+			Start(ctx, "kratos.Service.UpdateVerificationFlow").
+			Times(1).
+			Return(ctx, trace.SpanFromContext(ctx))
 
-        mockKratos.
-            EXPECT().
-            FrontendApi().
-            Times(2).
-            Return(mockFrontend)
+		mockKratos.
+			EXPECT().
+			FrontendApi().
+			Times(2).
+			Return(mockFrontend)
 
-        req := kClient.FrontendAPIUpdateVerificationFlowRequest{
-            ApiService: mockFrontend,
-        }
+		req := kClient.FrontendAPIUpdateVerificationFlowRequest{
+			ApiService: mockFrontend,
+		}
 
-        mockFrontend.
-            EXPECT().
-            UpdateVerificationFlow(ctx).
-            Times(1).
-            Return(req)
+		mockFrontend.
+			EXPECT().
+			UpdateVerificationFlow(ctx).
+			Times(1).
+			Return(req)
 
-        mockFrontend.
-            EXPECT().
-            UpdateVerificationFlowExecute(gomock.Any()).
-            Times(1).
-            Return(nil, nil, fmt.Errorf("kratos error"))
+		mockFrontend.
+			EXPECT().
+			UpdateVerificationFlowExecute(gomock.Any()).
+			Times(1).
+			Return(nil, nil, fmt.Errorf("kratos error"))
 
-        mockLogger.
-            EXPECT().
-            Errorf(gomock.Any(), gomock.Any()).
-            Times(1)
+		mockLogger.
+			EXPECT().
+			Errorf(gomock.Any(), gomock.Any()).
+			Times(1)
 
-        svc := NewService(mockKratos, nil, nil, nil, false, mockTracer, mockMonitor, mockLogger)
+		svc := NewService(mockKratos, nil, nil, nil, false, mockTracer, mockMonitor, mockLogger)
 
-        f, c, err := svc.UpdateVerificationFlow(ctx, flowID, body, nil)
+		f, c, err := svc.UpdateVerificationFlow(ctx, flowID, body, nil)
 
-        if f != nil {
-            t.Fatalf("expected flow nil, got %v", f)
-        }
-        if c != nil {
-            t.Fatalf("expected cookies nil, got %v", c)
-        }
-        if err == nil {
-            t.Fatalf("expected error, got nil")
-        }
-    })
+		if f != nil {
+			t.Fatalf("expected flow nil, got %v", f)
+		}
+		if c != nil {
+			t.Fatalf("expected cookies nil, got %v", c)
+		}
+		if err == nil {
+			t.Fatalf("expected error, got nil")
+		}
+	})
 
-    t.Run("success without response cookies", func(t *testing.T) {
-        ctrl := gomock.NewController(t)
-        defer ctrl.Finish()
+	t.Run("success without response cookies", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
 
-        ctx := context.Background()
-        mockTracer := NewMockTracingInterface(ctrl)
-        mockLogger := NewMockLoggerInterface(ctrl)
-        mockKratos := NewMockKratosClientInterface(ctrl)
-        mockFrontend := NewMockFrontendAPI(ctrl)
-        mockMonitor := monitoring.NewMockMonitorInterface(ctrl)
+		ctx := context.Background()
+		mockTracer := NewMockTracingInterface(ctrl)
+		mockLogger := NewMockLoggerInterface(ctrl)
+		mockKratos := NewMockKratosClientInterface(ctrl)
+		mockFrontend := NewMockFrontendAPI(ctrl)
+		mockMonitor := monitoring.NewMockMonitorInterface(ctrl)
 
-        flowID := "flow-id"
+		flowID := "flow-id"
 
-        mockTracer.
-            EXPECT().
-            Start(ctx, "kratos.Service.UpdateVerificationFlow").
-            Times(1).
-            Return(ctx, trace.SpanFromContext(ctx))
+		mockTracer.
+			EXPECT().
+			Start(ctx, "kratos.Service.UpdateVerificationFlow").
+			Times(1).
+			Return(ctx, trace.SpanFromContext(ctx))
 
-        mockKratos.
-            EXPECT().
-            FrontendApi().
-            Times(2).
-            Return(mockFrontend)
+		mockKratos.
+			EXPECT().
+			FrontendApi().
+			Times(2).
+			Return(mockFrontend)
 
-        req := kClient.FrontendAPIUpdateVerificationFlowRequest{
-            ApiService: mockFrontend,
-        }
+		req := kClient.FrontendAPIUpdateVerificationFlowRequest{
+			ApiService: mockFrontend,
+		}
 
-        mockFrontend.
-            EXPECT().
-            UpdateVerificationFlow(ctx).
-            Times(1).
-            Return(req)
+		mockFrontend.
+			EXPECT().
+			UpdateVerificationFlow(ctx).
+			Times(1).
+			Return(req)
 
-        flow := &kClient.VerificationFlow{Id: flowID}
+		flow := &kClient.VerificationFlow{Id: flowID}
 
-        mockFrontend.
-            EXPECT().
-            UpdateVerificationFlowExecute(gomock.Any()).
-            Times(1).
-            Return(flow, nil, nil)
+		mockFrontend.
+			EXPECT().
+			UpdateVerificationFlowExecute(gomock.Any()).
+			Times(1).
+			Return(flow, nil, nil)
 
-        svc := NewService(mockKratos, nil, nil, nil, false, mockTracer, mockMonitor, mockLogger)
+		svc := NewService(mockKratos, nil, nil, nil, false, mockTracer, mockMonitor, mockLogger)
 
-        f, c, err := svc.UpdateVerificationFlow(ctx, flowID, body, nil)
+		f, c, err := svc.UpdateVerificationFlow(ctx, flowID, body, nil)
 
-        if err != nil {
-            t.Fatalf("expected nil error, got %v", err)
-        }
-        if f != flow {
-            t.Fatalf("expected flow %v, got %v", flow, f)
-        }
-        if c != nil {
-            t.Fatalf("expected cookies nil, got %v", c)
-        }
-    })
+		if err != nil {
+			t.Fatalf("expected nil error, got %v", err)
+		}
+		if f != flow {
+			t.Fatalf("expected flow %v, got %v", flow, f)
+		}
+		if c != nil {
+			t.Fatalf("expected cookies nil, got %v", c)
+		}
+	})
 
-    t.Run("success with response cookies", func(t *testing.T) {
-        ctrl := gomock.NewController(t)
-        defer ctrl.Finish()
+	t.Run("success with response cookies", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
 
-        ctx := context.Background()
-        mockTracer := NewMockTracingInterface(ctrl)
-        mockLogger := NewMockLoggerInterface(ctrl)
-        mockKratos := NewMockKratosClientInterface(ctrl)
-        mockFrontend := NewMockFrontendAPI(ctrl)
-        mockMonitor := monitoring.NewMockMonitorInterface(ctrl)
+		ctx := context.Background()
+		mockTracer := NewMockTracingInterface(ctrl)
+		mockLogger := NewMockLoggerInterface(ctrl)
+		mockKratos := NewMockKratosClientInterface(ctrl)
+		mockFrontend := NewMockFrontendAPI(ctrl)
+		mockMonitor := monitoring.NewMockMonitorInterface(ctrl)
 
-        flowID := "flow-id"
+		flowID := "flow-id"
 
-        mockTracer.
-            EXPECT().
-            Start(ctx, "kratos.Service.UpdateVerificationFlow").
-            Times(1).
-            Return(ctx, trace.SpanFromContext(ctx))
+		mockTracer.
+			EXPECT().
+			Start(ctx, "kratos.Service.UpdateVerificationFlow").
+			Times(1).
+			Return(ctx, trace.SpanFromContext(ctx))
 
-        mockKratos.
-            EXPECT().
-            FrontendApi().
-            Times(2).
-            Return(mockFrontend)
+		mockKratos.
+			EXPECT().
+			FrontendApi().
+			Times(2).
+			Return(mockFrontend)
 
-        req := kClient.FrontendAPIUpdateVerificationFlowRequest{
-            ApiService: mockFrontend,
-        }
+		req := kClient.FrontendAPIUpdateVerificationFlowRequest{
+			ApiService: mockFrontend,
+		}
 
-        mockFrontend.
-            EXPECT().
-            UpdateVerificationFlow(ctx).
-            Times(1).
-            Return(req)
+		mockFrontend.
+			EXPECT().
+			UpdateVerificationFlow(ctx).
+			Times(1).
+			Return(req)
 
-        flow := &kClient.VerificationFlow{Id: flowID}
+		flow := &kClient.VerificationFlow{Id: flowID}
 
-        cookie := &http.Cookie{Name: "kratos", Value: "test"}
-        resp := &http.Response{
-            Header: http.Header{"Set-Cookie": []string{cookie.Raw}},
-        }
+		cookie := &http.Cookie{Name: "kratos", Value: "test"}
+		resp := &http.Response{
+			Header: http.Header{"Set-Cookie": []string{cookie.Raw}},
+		}
 
-        mockFrontend.
-            EXPECT().
-            UpdateVerificationFlowExecute(gomock.Any()).
-            Times(1).
-            Return(flow, resp, nil)
+		mockFrontend.
+			EXPECT().
+			UpdateVerificationFlowExecute(gomock.Any()).
+			Times(1).
+			Return(flow, resp, nil)
 
-        svc := NewService(mockKratos, nil, nil, nil, false, mockTracer, mockMonitor, mockLogger)
+		svc := NewService(mockKratos, nil, nil, nil, false, mockTracer, mockMonitor, mockLogger)
 
-        f, c, err := svc.UpdateVerificationFlow(ctx, flowID, body, nil)
+		f, c, err := svc.UpdateVerificationFlow(ctx, flowID, body, nil)
 
-        if err != nil {
-            t.Fatalf("expected nil error, got %v", err)
-        }
-        if f != flow {
-            t.Fatalf("expected flow %v, got %v", flow, f)
-        }
-        if !reflect.DeepEqual(c, resp.Cookies()) {
-            t.Fatalf("expected cookies %v, got %v", resp.Cookies(), c)
-        }
-    })
+		if err != nil {
+			t.Fatalf("expected nil error, got %v", err)
+		}
+		if f != flow {
+			t.Fatalf("expected flow %v, got %v", flow, f)
+		}
+		if !reflect.DeepEqual(c, resp.Cookies()) {
+			t.Fatalf("expected cookies %v, got %v", resp.Cookies(), c)
+		}
+	})
 }

--- a/pkg/kratos/service_test.go
+++ b/pkg/kratos/service_test.go
@@ -2418,7 +2418,7 @@ func TestParseLoginFlowOidcMethodBody(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodPost, "http://some/path", io.NopCloser(bytes.NewBuffer(jsonBody)))
 
-	b, _, err := NewService(mockKratos, mockAdminKratos, mockHydra, mockAuthz, false, false, mockTracer, mockMonitor, mockLogger).ParseLoginFlowMethodBody(req)
+	b, _, err := NewService(mockKratos, mockAdminKratos, mockHydra, mockAuthz, false, false, mockTracer, mockMonitor, mockLogger).ParseLoginFlowMethodBody(req, "aal1")
 
 	actual, _ := b.MarshalJSON()
 	expected, _ := body.MarshalJSON()
@@ -2451,7 +2451,7 @@ func TestParseLoginFlowPasswordMethodBody(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodPost, "http://some/path", io.NopCloser(bytes.NewBuffer(jsonBody)))
 
-	b, _, err := NewService(mockKratos, mockAdminKratos, mockHydra, mockAuthz, false, false, mockTracer, mockMonitor, mockLogger).ParseLoginFlowMethodBody(req)
+	b, _, err := NewService(mockKratos, mockAdminKratos, mockHydra, mockAuthz, false, false, mockTracer, mockMonitor, mockLogger).ParseLoginFlowMethodBody(req, "aal1")
 
 	actual, _ := b.MarshalJSON()
 	expected, _ := body.MarshalJSON()
@@ -2485,7 +2485,7 @@ func TestParseLoginFlowTotpMethodBody(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodPost, "http://some/path", io.NopCloser(bytes.NewBuffer(jsonBody)))
 
-	b, _, err := NewService(mockKratos, mockAdminKratos, mockHydra, mockAuthz, false, false, mockTracer, mockMonitor, mockLogger).ParseLoginFlowMethodBody(req)
+	b, _, err := NewService(mockKratos, mockAdminKratos, mockHydra, mockAuthz, false, false, mockTracer, mockMonitor, mockLogger).ParseLoginFlowMethodBody(req, "aal1")
 
 	actual, _ := b.MarshalJSON()
 	expected, _ := body.MarshalJSON()
@@ -2519,7 +2519,7 @@ func TestParseLoginFlowLookupSecretMethodBody(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodPost, "http://some/path", io.NopCloser(bytes.NewBuffer(jsonBody)))
 
-	b, _, err := NewService(mockKratos, mockAdminKratos, mockHydra, mockAuthz, false, false, mockTracer, mockMonitor, mockLogger).ParseLoginFlowMethodBody(req)
+	b, _, err := NewService(mockKratos, mockAdminKratos, mockHydra, mockAuthz, false, false, mockTracer, mockMonitor, mockLogger).ParseLoginFlowMethodBody(req, "aal1")
 
 	actual, _ := b.MarshalJSON()
 	expected, _ := body.MarshalJSON()
@@ -2553,7 +2553,7 @@ func TestParseLoginFlowWebAuthnMethodBody(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodPost, "http://some/path", io.NopCloser(bytes.NewBuffer(jsonBody)))
 
-	b, _, err := NewService(mockKratos, mockAdminKratos, mockHydra, mockAuthz, false, false, mockTracer, mockMonitor, mockLogger).ParseLoginFlowMethodBody(req)
+	b, _, err := NewService(mockKratos, mockAdminKratos, mockHydra, mockAuthz, false, false, mockTracer, mockMonitor, mockLogger).ParseLoginFlowMethodBody(req, "aal1")
 
 	actual, _ := b.MarshalJSON()
 	expected, _ := body.MarshalJSON()
@@ -2563,6 +2563,53 @@ func TestParseLoginFlowWebAuthnMethodBody(t *testing.T) {
 	}
 	if err != nil {
 		t.Fatalf("expected error to be nil not  %v", err)
+	}
+}
+
+// TestParseLoginFlowWebAuthnMethodBodyPreservesSessionCookieForAAL2 is a regression
+// test for issue #839: when webauthn is used as a 2FA method (alongside TOTP), the
+// Kratos session cookie must NOT be stripped, because Kratos needs it to associate
+// the webauthn authentication with the existing AAL1 session.
+// With oidcWebAuthnSequencingEnabled=false the old code treated webauthn as 1FA and
+// therefore incorrectly filtered the session cookie.
+func TestParseLoginFlowWebAuthnMethodBodyPreservesSessionCookieForAAL2(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := NewMockLoggerInterface(ctrl)
+	mockHydra := NewMockHydraClientInterface(ctrl)
+	mockKratos := NewMockKratosClientInterface(ctrl)
+	mockAdminKratos := NewMockKratosAdminClientInterface(ctrl)
+	mockAuthz := NewMockAuthorizerInterface(ctrl)
+	mockTracer := NewMockTracingInterface(ctrl)
+	mockMonitor := monitoring.NewMockMonitorInterface(ctrl)
+
+	flow := kClient.NewUpdateLoginFlowWithWebAuthnMethodWithDefaults()
+	flow.SetMethod("webauthn")
+
+	body := kClient.UpdateLoginFlowWithWebAuthnMethodAsUpdateLoginFlowBody(flow)
+	jsonBody, _ := body.MarshalJSON()
+
+	req := httptest.NewRequest(http.MethodPost, "http://some/path", io.NopCloser(bytes.NewBuffer(jsonBody)))
+	req.AddCookie(&http.Cookie{Name: KRATOS_SESSION_COOKIE_NAME, Value: "session_token"})
+
+	// oidcWebAuthnSequencingEnabled=false (standard MFA mode), requestedAAL="aal2" (2FA step)
+	_, cookies, err := NewService(mockKratos, mockAdminKratos, mockHydra, mockAuthz, false, false, mockTracer, mockMonitor, mockLogger).ParseLoginFlowMethodBody(req, "aal2")
+
+	if err != nil {
+		t.Fatalf("expected error to be nil not %v", err)
+	}
+
+	sessionCookiePresent := false
+	for _, c := range cookies {
+		if c.Name == KRATOS_SESSION_COOKIE_NAME {
+			sessionCookiePresent = true
+			break
+		}
+	}
+
+	if !sessionCookiePresent {
+		t.Fatal("bug #839: session cookie was incorrectly stripped for webauthn 2FA when oidcWebAuthnSequencingEnabled=false")
 	}
 }
 
@@ -2598,7 +2645,7 @@ func TestGetProviderNameOidc(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodPost, "http://some/path", io.NopCloser(bytes.NewBuffer(jsonBody)))
 
-	b, _, _ := NewService(mockKratos, mockAdminKratos, mockHydra, mockAuthz, false, false, mockTracer, mockMonitor, mockLogger).ParseLoginFlowMethodBody(req)
+	b, _, _ := NewService(mockKratos, mockAdminKratos, mockHydra, mockAuthz, false, false, mockTracer, mockMonitor, mockLogger).ParseLoginFlowMethodBody(req, "aal1")
 
 	actualProviderName := b.UpdateLoginFlowWithOidcMethod.Provider
 	if expectedProviderName != actualProviderName {

--- a/ui/components/NodeInputUrl.tsx
+++ b/ui/components/NodeInputUrl.tsx
@@ -25,6 +25,7 @@ export const NodeInputUrl: FC<NodeInputProps> = ({ node }) => {
       onClick={isWebauthnLogin ? handleWebauthnLogin : undefined}
       className={isWebauthnLogin ? "oidc-login-button" : ""}
       tabIndex={4}
+      type="button"
     >
       <img
         src="logos/Fallback.svg"

--- a/ui/pages/login.tsx
+++ b/ui/pages/login.tsx
@@ -68,8 +68,14 @@ const Login: NextPage = () => {
   const [flow, setFlow] = useState<LoginFlow>();
   const [isSequencedLogin, setSequencedLogin] = useState(false);
   const isAuthCode = flow?.ui.nodes.find((node) => node.group === "totp");
+  // Only auto-select the WebAuthn form when WebAuthn is the *sole* 2FA method.
+  // When TOTP is also registered the selection page must show both options so the
+  // user can choose either; forcing WebAuthn directly would hide TOTP and, when
+  // the ceremony fails, clicking "I want to use another method" restarts the
+  // entire login at the identifier page (see issue #839).
   const is2FaWebauthn =
     flow?.requested_aal === "aal2" &&
+    !isAuthCode &&
     flow?.ui.nodes.find((node) => node.group === "webauthn") !== undefined;
 
   const isIdentifierFirst =
@@ -368,7 +374,7 @@ const Login: NextPage = () => {
     });
 
     // add security key option that looks like an oidc input
-    if (!isWebauthn && !isAuthCode && !useBackupCode && supportsWebauthn) {
+    if (!isWebauthn && !useBackupCode && supportsWebauthn) {
       renderFlow.ui.nodes.push({
         attributes: {
           type: "url",
@@ -395,9 +401,10 @@ const Login: NextPage = () => {
       return toValue(a) - toValue(b);
     });
 
-    // autosubmit webauthn in case email is provided
+    // autosubmit webauthn in case email is provided (1FA only — in AAL2 the
+    // identity is already known from the session, so skip auto-submit)
     const email = urlParams.get("email");
-    if (isWebauthn && email) {
+    if (isWebauthn && email && flow?.requested_aal !== "aal2") {
       void handleSubmit({
         method: "webauthn",
         identifier: email,
@@ -415,6 +422,19 @@ const Login: NextPage = () => {
   if (!flow) {
     return;
   }
+
+  // When WebAuthn is shown but TOTP is also registered, "I want to use another
+  // method" should return to the TOTP selection page (strip ?webauthn=true and
+  // ?email= from the URL).  When WebAuthn is the sole 2FA method there is no
+  // other method to fall back to, so point at flow.return_to instead.
+  const anotherMethodUrl = isAuthCode
+    ? (() => {
+        const url = new URL(window.location.href);
+        url.searchParams.delete("webauthn");
+        url.searchParams.delete("email");
+        return url.toString();
+      })()
+    : flow?.return_to;
 
   renderFlow?.ui.nodes.map((node) => {
     if (isSignInWithPassword(node)) {
@@ -481,7 +501,7 @@ const Login: NextPage = () => {
             <Spinner />
           )}
           {isWebauthn && !isSequencedLogin && (
-            <a href={flow?.return_to}>I want to use another method</a>
+            <a href={anotherMethodUrl}>I want to use another method</a>
           )}
           {isWebauthn && isSequencedLogin && (
             <CheckboxInput

--- a/ui/pages/login.tsx
+++ b/ui/pages/login.tsx
@@ -68,8 +68,14 @@ const Login: NextPage = () => {
   const [flow, setFlow] = useState<LoginFlow>();
   const [isSequencedLogin, setSequencedLogin] = useState(false);
   const isAuthCode = flow?.ui.nodes.find((node) => node.group === "totp");
+  // Only auto-select the WebAuthn form when WebAuthn is the *sole* 2FA method.
+  // When TOTP is also registered the selection page must show both options so the
+  // user can choose either; forcing WebAuthn directly would hide TOTP and, when
+  // the ceremony fails, clicking "I want to use another method" restarts the
+  // entire login at the identifier page (see issue #839).
   const is2FaWebauthn =
     flow?.requested_aal === "aal2" &&
+    !isAuthCode &&
     flow?.ui.nodes.find((node) => node.group === "webauthn") !== undefined;
 
   const isIdentifierFirst =
@@ -372,7 +378,7 @@ const Login: NextPage = () => {
     });
 
     // add security key option that looks like an oidc input
-    if (!isWebauthn && !isAuthCode && !useBackupCode && supportsWebauthn) {
+    if (!isWebauthn && !useBackupCode && supportsWebauthn) {
       renderFlow.ui.nodes.push({
         attributes: {
           type: "url",
@@ -399,9 +405,10 @@ const Login: NextPage = () => {
       return toValue(a) - toValue(b);
     });
 
-    // autosubmit webauthn in case email is provided
+    // autosubmit webauthn in case email is provided (1FA only — in AAL2 the
+    // identity is already known from the session, so skip auto-submit)
     const email = urlParams.get("email");
-    if (isWebauthn && email) {
+    if (isWebauthn && email && flow?.requested_aal !== "aal2") {
       void handleSubmit({
         method: "webauthn",
         identifier: email,
@@ -419,6 +426,19 @@ const Login: NextPage = () => {
   if (!flow) {
     return;
   }
+
+  // When WebAuthn is shown but TOTP is also registered, "I want to use another
+  // method" should return to the TOTP selection page (strip ?webauthn=true and
+  // ?email= from the URL).  When WebAuthn is the sole 2FA method there is no
+  // other method to fall back to, so point at flow.return_to instead.
+  const anotherMethodUrl = isAuthCode
+    ? (() => {
+        const url = new URL(window.location.href);
+        url.searchParams.delete("webauthn");
+        url.searchParams.delete("email");
+        return url.toString();
+      })()
+    : flow?.return_to;
 
   renderFlow?.ui.nodes.map((node) => {
     if (isSignInWithPassword(node)) {
@@ -485,7 +505,7 @@ const Login: NextPage = () => {
             <Spinner />
           )}
           {isWebauthn && !isSequencedLogin && (
-            <a href={flow?.return_to}>I want to use another method</a>
+            <a href={anotherMethodUrl}>I want to use another method</a>
           )}
           {isWebauthn && isSequencedLogin && (
             <CheckboxInput


### PR DESCRIPTION
If a user had set up totp and webauthn as 2fa, they were not able to use webauthn. This PR fixes that.

[0c26ce3b88bccc8eb4b542eec3957ee4da357000.webm](https://github.com/user-attachments/assets/994f294f-b13b-4720-b271-2c839739a466)

[5c74aae48b00c6e77b4edda5c3cd51f8ed1b9328.webm](https://github.com/user-attachments/assets/be3d6b4f-56ea-4605-841f-bf8c72cbc867)

Closes #839