### PR TITLE
Fix smaller issues: main handlers in the backend and uniform capitalization of error messages on frontend

### DIFF
--- a/pkg/kratos/handlers.go
+++ b/pkg/kratos/handlers.go
@@ -12,9 +12,10 @@ import (
 	"strconv"
 	"time"
 
-	httpHelpers "github.com/canonical/identity-platform-login-ui/internal/misc/http"
 	"github.com/go-chi/chi/v5"
 	client "github.com/ory/kratos-client-go/v25"
+
+	httpHelpers "github.com/canonical/identity-platform-login-ui/internal/misc/http"
 
 	"github.com/canonical/identity-platform-login-ui/internal/logging"
 	"github.com/canonical/identity-platform-login-ui/internal/tracing"
@@ -861,7 +862,7 @@ func (a *API) handleKratosError(w http.ResponseWriter, r *http.Request) {
 	q := r.URL.Query()
 	id := q.Get("id")
 
-	flowError, cookies, err := a.service.GetFlowError(context.Background(), id)
+	flowError, cookies, err := a.service.GetFlowError(r.Context(), id)
 	if err != nil {
 		a.logger.Errorf("Error when getting flow error: %v\n", err)
 		http.Error(w, "Failed to get flow error", http.StatusInternalServerError)
@@ -882,7 +883,15 @@ func (a *API) handleKratosError(w http.ResponseWriter, r *http.Request) {
 func (a *API) handleGetRecoveryFlow(w http.ResponseWriter, r *http.Request) {
 	q := r.URL.Query()
 
-	flow, cookies, err := a.service.GetRecoveryFlow(context.Background(), q.Get("id"), r.Cookies())
+	flowId := q.Get("id")
+	if flowId == "" {
+		a.logger.Errorf("ID parameter not present")
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode("ID parameter not present")
+		return
+	}
+
+	flow, cookies, err := a.service.GetRecoveryFlow(r.Context(), flowId, r.Cookies())
 	if err != nil {
 		a.logger.Errorf("Error when getting recovery flow: %v\n", err)
 		http.Error(w, "Failed to get recovery flow", http.StatusInternalServerError)
@@ -943,7 +952,7 @@ func (a *API) handleCreateRecoveryFlow(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	flow, cookies, err := a.service.CreateBrowserRecoveryFlow(context.Background(), returnTo)
+	flow, cookies, err := a.service.CreateBrowserRecoveryFlow(r.Context(), returnTo)
 	if err != nil {
 		a.logger.Errorf("Failed to create recovery flow: %v\n", err)
 		http.Error(w, "Failed to create recovery flow", http.StatusInternalServerError)
@@ -970,7 +979,15 @@ func (a *API) handleCreateRecoveryFlow(w http.ResponseWriter, r *http.Request) {
 func (a *API) handleGetSettingsFlow(w http.ResponseWriter, r *http.Request) {
 	q := r.URL.Query()
 
-	flow, response, err := a.service.GetSettingsFlow(context.Background(), q.Get("id"), r.Cookies())
+	flowId := q.Get("id")
+	if flowId == "" {
+		a.logger.Errorf("ID parameter not present")
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode("ID parameter not present")
+		return
+	}
+
+	flow, response, err := a.service.GetSettingsFlow(r.Context(), flowId, r.Cookies())
 	if err != nil {
 		a.logger.Errorf("Error when getting settings flow: %v\n", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -1008,7 +1025,7 @@ func (a *API) handleUpdateSettingsFlow(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	flow, redirectInfo, cookies, err := a.service.UpdateSettingsFlow(context.Background(), flowId, *body, r.Cookies())
+	flow, redirectInfo, cookies, err := a.service.UpdateSettingsFlow(r.Context(), flowId, *body, r.Cookies())
 	if err != nil {
 		a.logger.Errorf("Error when updating settings flow: %v\n", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -1110,7 +1127,7 @@ func (a *API) settingsReturnToURL(r *http.Request, flowId string) (string, error
 func (a *API) handleCreateSettingsFlow(w http.ResponseWriter, r *http.Request) {
 	returnTo := r.URL.Query().Get("return_to")
 
-	flow, response, err := a.service.CreateBrowserSettingsFlow(context.Background(), returnTo, r.Cookies())
+	flow, response, err := a.service.CreateBrowserSettingsFlow(r.Context(), returnTo, r.Cookies())
 	if err != nil {
 		a.logger.Errorf("Failed to create settings flow: %v", err)
 		http.Error(w, "Failed to create settings flow", http.StatusInternalServerError)

--- a/ui/components/Flow.tsx
+++ b/ui/components/Flow.tsx
@@ -14,6 +14,7 @@ import { getNodeId, isUiNodeInputAttributes } from "@ory/integrations/ui";
 import React, { Component, FormEvent } from "react";
 import { Node } from "./Node";
 import { FlowContext } from "../context/FlowContext";
+import { capitalize } from "../util/handleFlowError";
 
 export type Values = Partial<
   | UpdateLoginFlowBody
@@ -219,7 +220,7 @@ export class Flow<T extends Values> extends Component<Props<T>, State<T>> {
               <Node
                 key={`${id}-${k}`}
                 disabled={isLoading}
-                error={error}
+                error={capitalize(error)}
                 node={node}
                 value={values[id]}
                 dispatchSubmit={this.handleSubmit}

--- a/ui/components/NodeInputEmail.tsx
+++ b/ui/components/NodeInputEmail.tsx
@@ -2,6 +2,7 @@ import { getNodeLabel } from "@ory/integrations/ui";
 import { Input } from "@canonical/react-components";
 import React, { FC, useCallback, useEffect } from "react";
 import { NodeInputProps } from "./helpers";
+import { capitalize } from "../util/handleFlowError";
 
 export const NodeInputEmail: FC<NodeInputProps> = ({
   node,
@@ -34,7 +35,7 @@ export const NodeInputEmail: FC<NodeInputProps> = ({
     const isInvalid = !emailRegex.test((value as string) ?? "") && value !== "";
     const localError = isInvalid ? "Incorrect email address" : undefined;
     const error = localError ?? upstreamError;
-    return error;
+    return capitalize(error);
   }, [value, upstreamError]);
 
   const emailValidationOnBlur = useCallback(() => {

--- a/ui/components/NodeInputText.tsx
+++ b/ui/components/NodeInputText.tsx
@@ -9,6 +9,7 @@ import {
 } from "../util/constants";
 import { UiNodeInputAttributes } from "@ory/client/api";
 import { ORY_ERR_ACCOUNT_NOT_FOUND_OR_NO_LOGIN_METHOD } from "../util/constants";
+import { capitalize } from "../util/handleFlowError";
 
 export const NodeInputText: FC<NodeInputProps> = ({
   attributes,
@@ -30,9 +31,6 @@ export const NodeInputText: FC<NodeInputProps> = ({
   const isWebauthn = urlParams.get("webauthn") === "true";
   const isIdentifierFirstGroup = node.group === "identifier_first";
   const isEmailInput = node.meta?.label?.text?.toLowerCase?.() === "email";
-
-  const ucFirst = (s?: string) =>
-    s ? String(s[0]).toUpperCase() + String(s).slice(1) : s;
 
   let deduplicateValues: string[] = [];
   if (node.meta.label?.context) {
@@ -124,7 +122,7 @@ export const NodeInputText: FC<NodeInputProps> = ({
       attributes.name === "lookup_secret" ||
       (isWebauthn && attributes.name === "identifier")
     ) {
-      return ucFirst(error);
+      return capitalize(error);
     }
 
     return error;
@@ -216,7 +214,7 @@ export const NodeInputText: FC<NodeInputProps> = ({
         disabled={disabled}
         placeholder={getPlaceholderText()}
         value={inputValue}
-        error={getError}
+        error={capitalize(getError)}
         onChange={handleChange}
         onKeyDown={handleKeyDown}
         maxLength={isVerificationCodeInput(node) ? 6 : undefined}

--- a/ui/components/RegisterPassword.tsx
+++ b/ui/components/RegisterPassword.tsx
@@ -15,7 +15,7 @@ import { AxiosError } from "axios";
 import { kratos } from "../api/kratos";
 import { redirectTo } from "../util/redirectTo";
 import { useRouter } from "next/router";
-import { handleFlowError } from "../util/handleFlowError";
+import { capitalize, handleFlowError } from "../util/handleFlowError";
 
 interface RegisterPasswordProps {
   flow: RegistrationFlow | undefined;
@@ -107,7 +107,7 @@ export const RegisterPassword = ({ flow, setFlow }: RegisterPasswordProps) => {
         .catch((err: AxiosError<string>) => {
           console.error("Error after handling flow error:", err);
           setFlowError(
-            err.response?.data ||
+            capitalize(err.response?.data) ||
               "An unexpected error occurred. Please try again.",
           );
         })

--- a/ui/util/handleFlowError.ts
+++ b/ui/util/handleFlowError.ts
@@ -13,6 +13,11 @@ const getRedirectToFromError = (err: KratosErrorResponse) => (
   window.location.href = err.redirect_browser_to? err.redirect_browser_to: err.redirect_to
 );
 
+export function capitalize(str?: string){
+  if (!str) return str;
+  return str.charAt(0).toUpperCase() + str.slice(1)
+}
+
 // deal with errors coming from initializing a flow.
 export const handleFlowError =
   <S>(


### PR DESCRIPTION
## Description
Uniformed error messages by capitalizing strings.
Small refactors on kratos/handlers.go to properly use context and validate the presence of the `id` query parameter.

Fixes #886 