### PR TITLE
fix: avoid query param passing (with flow param) when switching flows

### DIFF
--- a/ui/pages/verification.tsx
+++ b/ui/pages/verification.tsx
@@ -177,12 +177,12 @@ const Verification: NextPage = () => {
         .then(({ data }) => {
           if (data.state === "passed_challenge") {
             if (flow?.return_to) {
-              redirectTo(flow.return_to, router);
+              redirectTo(flow.return_to, router, false);
               return;
             } else {
               const timer = setTimeout(() => {
                 clearTimeout(timer);
-                redirectTo(`/ui/manage_details`, router);
+                redirectTo(`/ui/manage_details`, router, false);
               }, 3000);
             }
           }

--- a/ui/util/redirectTo.ts
+++ b/ui/util/redirectTo.ts
@@ -1,6 +1,6 @@
 import { NextRouter } from "next/router";
 
-export function redirectTo(url: string, router: NextRouter): void {
+export function redirectTo(url: string, router: NextRouter, passQuery: boolean = true): void {
   let newUrl: URL;
   try {
     newUrl = new URL(url, window.location.origin);
@@ -22,7 +22,7 @@ export function redirectTo(url: string, router: NextRouter): void {
   void router.push({
     pathname: pathWithoutBase,
     query: {
-      ...router.query,
+      ...(passQuery ? router.query : {}),
       ...kratosParams,
     },
     hash: newUrl.hash,


### PR DESCRIPTION
## Description
Fixing a behavior of the redirection logic used in the verification flow where the flow id for verification gets re-used for other flows causing issues in the page you get redirected to.


Fixes #874 