### PR TITLE
fix: update OIDC hooks and clear traits for registration flow

### DIFF
--- a/docker/kratos/kratos.yml
+++ b/docker/kratos/kratos.yml
@@ -60,7 +60,8 @@ selfservice:
                         - hook: session
                 oidc:
                     hooks:
-                    - hook: session
+                        - hook: show_verification_ui
+                        - hook: session
                 webauthn:
                     hooks:
                     - hook: session

--- a/pkg/kratos/service.go
+++ b/pkg/kratos/service.go
@@ -1001,6 +1001,11 @@ func (s *Service) ParseRegistrationFlowMethodBody(r *http.Request) (*kClient.Upd
 		if err := parseBody(r.Body, &body); err != nil {
 			return nil, err
 		}
+		// Traits for OIDC registration must come from IdP-verified claims
+		// (docker/kratos/schema.jsonnet), never from client input. Without this,
+		// the identifier-first email (xxx@email.com) overrides the provider email
+		// (yyy@gmail.com) and the account registers under an unproven address.
+		body.Traits = nil
 		ret = kClient.UpdateRegistrationFlowWithOidcMethodAsUpdateRegistrationFlowBody(&body)
 	default:
 		return nil, fmt.Errorf("unknown method: %s", method)


### PR DESCRIPTION
#### Description

- Removes any traits directly passed in the POST call for registration flow.
- Adds kratos native oidc hooks to prevent squatting as used in the password flow.

#### Resolutions

- resolves #905 