### PR TITLE
fix(ui): IAM-2105-pasting-a-url-with-flow-id-in-a-new-tab-causes-stalling-500-status-code-returned-for-a-401-message

### DIFF
--- a/ui/util/handleFlowError.ts
+++ b/ui/util/handleFlowError.ts
@@ -99,6 +99,11 @@ export const handleFlowError =
         resetFlow(undefined);
         window.location.href = "./" + flowType;
         return;
+      case 401:
+        // Unauthorized, redirect to login
+        resetFlow(undefined);
+        window.location.href = "./login";
+        return;
     }
 
     // We are not able to handle the error? Return it.

--- a/ui/util/handleFlowError.ts
+++ b/ui/util/handleFlowError.ts
@@ -30,61 +30,69 @@ export const handleFlowError =
       | "verification",
     resetFlow: Dispatch<SetStateAction<S | undefined>>,
   ) =>
-  async (err: AxiosError<KratosErrorResponse>) => {
-    switch (err.response?.data.error?.id) {
-      case "session_aal2_required":
-        resetFlow(undefined);
-        // 2FA is enabled and enforced, but user did not perform 2fa yet!
-        window.location.href = getRedirectToFromError(err.response.data);
-        return;
-      case "session_already_available":
-        // User is already signed in, let's redirect them to settings
-        window.location.href = "./manage_details";
-        return;
-      case "session_refresh_required":
-        // We need to re-authenticate to perform this action
-        window.location.href = getRedirectToFromError(err.response.data);
-        return;
-      case "session_inactive":
-        // No session found, redirect the user to sign in
+  async (err: AxiosError<KratosErrorResponse | string>) => {
+    if (typeof err.response?.data === "string") {
+      // If the error response is a string, we can't handle it specifically, so just reject the promise.
+      if (err.response?.data.includes("401")) {
         resetFlow(undefined);
         window.location.href = "./login";
         return;
-      case "self_service_flow_return_to_forbidden":
-        // The flow expired, let's request a new one.
-        resetFlow(undefined);
-        window.location.href = "./" + flowType;
-        return;
-      case "self_service_flow_expired":
-        // The flow expired, let's request a new one.
-        resetFlow(undefined);
-        window.location.href = "./" + flowType;
-        return;
-      case "security_csrf_violation":
-        // A CSRF violation occurred. Best to just refresh the flow!
-        resetFlow(undefined);
-        window.location.href = "./" + flowType;
-        return;
-      case "security_identity_mismatch":
-        // The requested item was intended for someone else. Let's request a new flow...
-        resetFlow(undefined);
-        window.location.href = "./" + flowType;
-        return;
-      case "browser_location_change_required":
-        // Ory Kratos asked us to point the user to this URL.
-        window.location.href = getRedirectToFromError(err.response.data);
-        return;
-      case "tenant_selection_required":
-        // User already authenticated but hasn't picked a tenant yet
-        // (e.g. pressed the browser back button from tenant selection).
-        window.location.href = getRedirectToFromError(err.response.data);
-        return;
-      case "regenerate_backup_codes":
-        // The user logged in with a lookup secret and is running out of backup codes, redirect to generate a new set
-        window.location.href = getRedirectToFromError(err.response.data);
-        return;
+      }
+    } else {
+      switch (err.response?.data.error?.id) {
+        case "session_aal2_required":
+          resetFlow(undefined);
+          // 2FA is enabled and enforced, but user did not perform 2fa yet!
+          window.location.href = getRedirectToFromError(err.response.data);
+          return;
+        case "session_already_available":
+          // User is already signed in, let's redirect them to settings
+          window.location.href = "./manage_details";
+          return;
+        case "session_refresh_required":
+          // We need to re-authenticate to perform this action
+          window.location.href = getRedirectToFromError(err.response.data);
+          return;
+        case "session_inactive":
+          // No session found, redirect the user to sign in
+          resetFlow(undefined);
+          window.location.href = "./login";
+          return;
+        case "self_service_flow_return_to_forbidden":
+          // The flow expired, let's request a new one.
+          resetFlow(undefined);
+          window.location.href = "./" + flowType;
+          return;
+        case "self_service_flow_expired":
+          // The flow expired, let's request a new one.
+          resetFlow(undefined);
+          window.location.href = "./" + flowType;
+          return;
+        case "security_csrf_violation":
+          // A CSRF violation occurred. Best to just refresh the flow!
+          resetFlow(undefined);
+          window.location.href = "./" + flowType;
+          return;
+        case "security_identity_mismatch":
+          // The requested item was intended for someone else. Let's request a new flow...
+          resetFlow(undefined);
+          window.location.href = "./" + flowType;
+          return;
+        case "browser_location_change_required":
+          // Ory Kratos asked us to point the user to this URL.
+          window.location.href = getRedirectToFromError(err.response.data);
+          return;
+        case "tenant_selection_required":
+          // User already authenticated but hasn't picked a tenant yet
+          // (e.g. pressed the browser back button from tenant selection).
+          window.location.href = getRedirectToFromError(err.response.data);
+          return;
+        case "regenerate_backup_codes":
+          // The user logged in with a lookup secret and is running out of backup codes, redirect to generate a new set
+          window.location.href = getRedirectToFromError(err.response.data);
+          return;
+      }
     }
-
     switch (err.response?.status) {
       case 410:
         // The flow expired, let's request a new one.


### PR DESCRIPTION
## Description

Fixes the issue raised [here](https://github.com/canonical/identity-platform-login-ui/issues/880)

## QA

- Start with the registration flow at /ui/register
- After entering the password, the user will see a screen to setup their 2FA 
- Copy the link and paste it in an incognito browser
- User should be redirected to the login screen
